### PR TITLE
Fix packaging

### DIFF
--- a/ConTabs/ConTabs.csproj
+++ b/ConTabs/ConTabs.csproj
@@ -1,7 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.3</TargetFramework>
+    <TargetFrameworks>netstandard1.3;netstandard2.0;net45</TargetFrameworks>
+    <Title>ConTabs</Title>
+    <Version>0.2.0</Version>
+    <Description>Simple yet flexible ascii tables for your console output.</Description>
+    <Authors>tdwright</Authors>
+    <Copyright>Copyright 2017 (c) tdwright. All rights reserved.</Copyright>
+    <PackageId>ConTabs.tdwright</PackageId>
+    <PackageTags>ascii tables console</PackageTags>
+    <PackageReleaseNotes>First release</PackageReleaseNotes>
+    <PackageProjectUrl>https://github.com/tdwright/contabs</PackageProjectUrl>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">


### PR DESCRIPTION
1) as you've found out, you should use `dotnet pack` or `msbuild /t:pack` or `Pack` from rclick menu on project in VS and not `nuget.exe`
2) the dependencies you are talking about is just compat layer that should not concern you unless you are still using `packages.config` (`PackageReference` is a thing now even in old `.csproj`), however it is understandable that you want to avoid them either way - which is easily solved:
  * for .NET 4.7+ - target also `netstandard2.0`
  * for .NET 4.5+ - target also `net45`