### PR TITLE
Bugfix #13. Table<T>.Create(data) throws PublicPropertiesNotFoundException 

### DIFF
--- a/ConTabs.Tests/Table-Basic.cs
+++ b/ConTabs.Tests/Table-Basic.cs
@@ -1,6 +1,7 @@
 ﻿using NUnit.Framework;
 using Shouldly;
 using System.Collections.Generic;
+using ConTabs.Exceptions;
 using ConTabs.TestData;
 
 namespace ConTabs.Tests
@@ -43,7 +44,17 @@ namespace ConTabs.Tests
             // Assert
             table.Columns.Count.ShouldBe(4);
         }
-
+        
+        [Test]
+        public void Table_GivenClassWithoutPublicProperties_ThrowsPublicPropertiesNotFoundException()
+        {
+            // Arrange
+            var listOfTestClasses = DataProvider.ListOfInvalidTestData();
+   
+            // Assert
+            Assert.Throws<PublicPropertiesNotFoundException>(() =>
+                Table<InvalidTestDataType>.Create(listOfTestClasses));
+        }
     }
 
     

--- a/ConTabs/ConTabs.csproj
+++ b/ConTabs/ConTabs.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;netstandard2.0;net45</TargetFrameworks>
     <PackageId>ConTabs.tdwright</PackageId>
@@ -11,10 +10,8 @@
     <Copyright>Copyright 2017 (c) tdwright. All rights reserved.</Copyright>
     <PackageTags>ascii tables console</PackageTags>
   </PropertyGroup>
-
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DebugType>full</DebugType>
     <DebugSymbols>True</DebugSymbols>
   </PropertyGroup>
-
 </Project>

--- a/ConTabs/Exceptions/PublicPropertiesNotFoundException.cs
+++ b/ConTabs/Exceptions/PublicPropertiesNotFoundException.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace ConTabs.Exceptions
+{
+    public class PublicPropertiesNotFoundException : Exception
+    {
+        public override string Message =>
+            "On Table<T> creation, no valid properties were identified. Check access modifiers.";
+    }
+}

--- a/ConTabs/Table.cs
+++ b/ConTabs/Table.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using ConTabs.Exceptions;
 
 namespace ConTabs
 {
@@ -54,6 +55,8 @@ namespace ConTabs
                 .Where(p => p.GetMethod.IsPublic)
                 .Select(p => new Column(p.PropertyType, p.Name))
                 .ToList();
+            
+            if (!Columns.Any()) throw new PublicPropertiesNotFoundException();
         }
 
         public override string ToString()

--- a/ConTabsTestData/TestData.cs
+++ b/ConTabsTestData/TestData.cs
@@ -31,6 +31,18 @@ namespace ConTabs.TestData
             if (!limit.HasValue || limit < 0) limit = list.Count;
             return list.Take(limit.Value).ToList();
         }
+        
+        public static List<InvalidTestDataType> ListOfInvalidTestData()
+        {
+            var list = new List<InvalidTestDataType>
+            {
+                new InvalidTestDataType(),
+                new InvalidTestDataType(),
+                new InvalidTestDataType(),
+                new InvalidTestDataType(),
+            };
+            return list;
+        }
     }
 
     public class TestDataType
@@ -46,5 +58,14 @@ namespace ConTabs.TestData
     {
         public int IntA { get; set; }
         public int IntB { get; set; }
+    }
+    
+    public class InvalidTestDataType
+    {
+        private string StringColumn { get; set; }
+        private int IntColumn { get; set; }
+        private decimal CurrencyColumn { get; set; }
+        private DateTime DateTimeColumn { get; set; }
+        private string HiddenProp { get; set; }
     }
 }


### PR DESCRIPTION
Issue #13 describes a bug that can result in unwanted behavior. Classes which serve as data models for table creation and lack public properties would result in the construction of an empty and deformed table. A preferable behavior, as mentioned in the original issue, is to throw an exception which can be properly handled.

Now when an empty list of class properties is returned, and exception is thrown. In order for the exception to be descriptive, a custom exception PublicPropertiesNotFoundException was created. This has been tested and is passing.