### PR TITLE
Implemented long string behaviour, including word wrap

### DIFF
--- a/ConTabs.Tests/ConTabs.Tests.csproj
+++ b/ConTabs.Tests/ConTabs.Tests.csproj
@@ -53,6 +53,7 @@
     <Compile Include="FormatTests.cs" />
     <Compile Include="Table-Basic.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="LongStringBehaviourTests.cs" />
     <Compile Include="UsageTests.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/ConTabs.Tests/FormatTests.cs
+++ b/ConTabs.Tests/FormatTests.cs
@@ -107,7 +107,7 @@ namespace ConTabs.Tests
             var listOfTestClasses = DataProvider.ListOfTestData(2);
             var tableObj = Table<TestDataType>.Create(listOfTestClasses);
 
-            tableObj.Columns[1].Hide = true; // only show currency field
+            tableObj.Columns[1].Hide = true; // only show string field
             tableObj.Columns[2].Hide = true;
             tableObj.Columns[3].Hide = true;
 
@@ -123,6 +123,33 @@ namespace ConTabs.Tests
             expected += "| AAAA         |" + Environment.NewLine;
             expected += "| BB           |" + Environment.NewLine;
             expected += "+--------------+";
+            tableString.ShouldBe(expected);
+        }
+
+        [Test]
+        public void PropWithCustomToStringNotFormattedInTable()
+        {
+            // Arrange
+            var listOfTestClasses = DataProvider.ListOfExtendedTestData(2);
+            var tableObj = Table<ExtendedTestDataType>.Create(listOfTestClasses);
+
+            tableObj.Columns[1].Hide = true; // only show custom ToString type field
+            tableObj.Columns[2].Hide = true;
+            tableObj.Columns[3].Hide = true;
+            tableObj.Columns[4].Hide = true;
+
+            // Act
+            tableObj.Columns[0].FormatString = "£0.00";
+            var tableString = tableObj.ToString();
+
+            // Assert
+            string expected = "";
+            expected += "+----------------+" + Environment.NewLine;
+            expected += "| CustomToString |" + Environment.NewLine;
+            expected += "+----------------+" + Environment.NewLine;
+            expected += "| A              |" + Environment.NewLine;
+            expected += "| B              |" + Environment.NewLine;
+            expected += "+----------------+";
             tableString.ShouldBe(expected);
         }
     }

--- a/ConTabs.Tests/LongStringBehaviourTests.cs
+++ b/ConTabs.Tests/LongStringBehaviourTests.cs
@@ -9,7 +9,7 @@ namespace ConTabs.Tests
     [TestFixture]
     public class LongStringBehaviourTests
     {
-        public readonly string LongString = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec vehicula fringilla tortor.";
+        public readonly string LongString = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec-vehicula thisverylongwordwillneedtobesplit.";
         
         [Test]
         public void DefaultBehaviourShouldNotChangeString()
@@ -86,9 +86,10 @@ namespace ConTabs.Tests
             processedString.ShouldBe("" +
                 "Lorem ipsum dolor sit" + Environment.NewLine +
                 "amet, consectetur" + Environment.NewLine +
-                "adipiscing elit. Donec" + Environment.NewLine +
-                "vehicula fringilla" + Environment.NewLine +
-                "tortor.");
+                "adipiscing elit. Donec-" + Environment.NewLine +
+                "vehicula" + Environment.NewLine +
+                "thisverylongwordwillneed-" + Environment.NewLine +
+                "tobesplit.");
         }
     }
 }

--- a/ConTabs.Tests/LongStringBehaviourTests.cs
+++ b/ConTabs.Tests/LongStringBehaviourTests.cs
@@ -10,6 +10,7 @@ namespace ConTabs.Tests
     public class LongStringBehaviourTests
     {
         public readonly string LongString = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec-vehicula thisverylongwordwillneedtobesplit.";
+        public readonly string ShortString = "AAAA";
         
         [Test]
         public void DefaultBehaviourShouldNotChangeString()
@@ -35,10 +36,10 @@ namespace ConTabs.Tests
             tableObj.Columns[0].LongStringBehaviour = LongStringBehaviour.Truncate;
 
             // Act
-            var processedString = tableObj.Columns[0].StringValForCol("AAAA");
+            var processedString = tableObj.Columns[0].StringValForCol(ShortString);
 
             // Assert
-            processedString.ShouldBe("AAAA");
+            processedString.ShouldBe(ShortString);
         }
 
         [Test]
@@ -69,6 +70,21 @@ namespace ConTabs.Tests
 
             // Assert
             processedString.ShouldBe("Lorem ipsum ...");
+        }
+
+        [Test]
+        public void WordWrapBehaviourShouldNotWrapShortString()
+        {
+            // Arrange
+            var listOfTestClasses = DataProvider.ListOfTestData(1);
+            var tableObj = Table<TestDataType>.Create(listOfTestClasses);
+            tableObj.Columns[0].LongStringBehaviour = LongStringBehaviour.Wrap;
+
+            // Act
+            var processedString = tableObj.Columns[0].StringValForCol(ShortString);
+
+            // Assert
+            processedString.ShouldBe(ShortString);
         }
 
         [Test]

--- a/ConTabs.Tests/LongStringBehaviourTests.cs
+++ b/ConTabs.Tests/LongStringBehaviourTests.cs
@@ -10,31 +10,20 @@ namespace ConTabs.Tests
     public class LongStringBehaviourTests
     {
         public readonly string LongString = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec vehicula fringilla tortor.";
-
+        
         [Test]
         public void DefaultBehaviourShouldNotChangeString()
         {
             // Arrange
             var listOfTestClasses = DataProvider.ListOfTestData(1);
-            listOfTestClasses[0].StringColumn = LongString;
             var tableObj = Table<TestDataType>.Create(listOfTestClasses);
             tableObj.Columns[0].LongStringBehaviour = LongStringBehaviour.Default;
 
-            tableObj.Columns[1].Hide = true; // hide non-string fields 
-            tableObj.Columns[2].Hide = true;
-            tableObj.Columns[3].Hide = true;
-
             // Act
-            var tableString = tableObj.ToString();
+            var processedString = tableObj.Columns[0].StringValForCol(LongString);
 
             // Assert
-            string expected = "";
-            expected += "+-------------------------------------------------------------------------------------------+" + Environment.NewLine;
-            expected += "| StringColumn                                                                              |" + Environment.NewLine;
-            expected += "+-------------------------------------------------------------------------------------------+" + Environment.NewLine;
-            expected += "| Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec vehicula fringilla tortor. |" + Environment.NewLine;
-            expected += "+-------------------------------------------------------------------------------------------+";
-            tableString.ShouldBe(expected);
+            processedString.ShouldBe(LongString);
         }
 
         [Test]
@@ -45,21 +34,11 @@ namespace ConTabs.Tests
             var tableObj = Table<TestDataType>.Create(listOfTestClasses);
             tableObj.Columns[0].LongStringBehaviour = LongStringBehaviour.Truncate;
 
-            tableObj.Columns[1].Hide = true; // hide non-string fields 
-            tableObj.Columns[2].Hide = true;
-            tableObj.Columns[3].Hide = true;
-
             // Act
-            var tableString = tableObj.ToString();
+            var processedString = tableObj.Columns[0].StringValForCol("AAAA");
 
             // Assert
-            string expected = "";
-            expected += "+--------------+" + Environment.NewLine;
-            expected += "| StringColumn |" + Environment.NewLine;
-            expected += "+--------------+" + Environment.NewLine;
-            expected += "| AAAA         |" + Environment.NewLine;
-            expected += "+--------------+";
-            tableString.ShouldBe(expected);
+            processedString.ShouldBe("AAAA");
         }
 
         [Test]
@@ -67,25 +46,14 @@ namespace ConTabs.Tests
         {
             // Arrange
             var listOfTestClasses = DataProvider.ListOfTestData(1);
-            listOfTestClasses[0].StringColumn = LongString;
             var tableObj = Table<TestDataType>.Create(listOfTestClasses);
             tableObj.Columns[0].LongStringBehaviour = LongStringBehaviour.Truncate;
 
-            tableObj.Columns[1].Hide = true; // hide non-string fields 
-            tableObj.Columns[2].Hide = true;
-            tableObj.Columns[3].Hide = true;
-
             // Act
-            var tableString = tableObj.ToString();
+            var processedString = tableObj.Columns[0].StringValForCol(LongString);
 
             // Assert
-            string expected = "";
-            expected += "+-----------------+" + Environment.NewLine;
-            expected += "| StringColumn    |" + Environment.NewLine;
-            expected += "+-----------------+" + Environment.NewLine;
-            expected += "| Lorem ipsum dol |" + Environment.NewLine;
-            expected += "+-----------------+";
-            tableString.ShouldBe(expected);
+            processedString.ShouldBe("Lorem ipsum dol");
         }
 
         [Test]
@@ -93,25 +61,34 @@ namespace ConTabs.Tests
         {
             // Arrange
             var listOfTestClasses = DataProvider.ListOfTestData(1);
-            listOfTestClasses[0].StringColumn = LongString;
             var tableObj = Table<TestDataType>.Create(listOfTestClasses);
             tableObj.Columns[0].LongStringBehaviour = LongStringBehaviour.TruncateWithEllipsis;
 
-            tableObj.Columns[1].Hide = true; // hide non-string fields 
-            tableObj.Columns[2].Hide = true;
-            tableObj.Columns[3].Hide = true;
-
             // Act
-            var tableString = tableObj.ToString();
+            var processedString = tableObj.Columns[0].StringValForCol(LongString);
 
             // Assert
-            string expected = "";
-            expected += "+-----------------+" + Environment.NewLine;
-            expected += "| StringColumn    |" + Environment.NewLine;
-            expected += "+-----------------+" + Environment.NewLine;
-            expected += "| Lorem ipsum ... |" + Environment.NewLine;
-            expected += "+-----------------+";
-            tableString.ShouldBe(expected);
+            processedString.ShouldBe("Lorem ipsum ...");
+        }
+
+        [Test]
+        public void WordWrapBehaviourShouldWrapLongString()
+        {
+            // Arrange
+            var listOfTestClasses = DataProvider.ListOfTestData(1);
+            var tableObj = Table<TestDataType>.Create(listOfTestClasses);
+            tableObj.Columns[0].LongStringBehaviour = LongStringBehaviour.Wrap;
+
+            // Act
+            var processedString = tableObj.Columns[0].StringValForCol(LongString);
+
+            // Assert
+            processedString.ShouldBe("" +
+                "Lorem ipsum dolor sit" + Environment.NewLine +
+                "amet, consectetur" + Environment.NewLine +
+                "adipiscing elit. Donec" + Environment.NewLine +
+                "vehicula fringilla" + Environment.NewLine +
+                "tortor.");
         }
     }
 }

--- a/ConTabs.Tests/LongStringBehaviourTests.cs
+++ b/ConTabs.Tests/LongStringBehaviourTests.cs
@@ -1,5 +1,4 @@
 ﻿using ConTabs.TestData;
-using ConTabs;
 using NUnit.Framework;
 using Shouldly;
 using System;

--- a/ConTabs.Tests/LongStringBehaviourTests.cs
+++ b/ConTabs.Tests/LongStringBehaviourTests.cs
@@ -1,0 +1,117 @@
+﻿using ConTabs.TestData;
+using ConTabs;
+using NUnit.Framework;
+using Shouldly;
+using System;
+
+namespace ConTabs.Tests
+{
+    [TestFixture]
+    public class LongStringBehaviourTests
+    {
+        public readonly string LongString = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec vehicula fringilla tortor.";
+
+        [Test]
+        public void DefaultBehaviourShouldNotChangeString()
+        {
+            // Arrange
+            var listOfTestClasses = DataProvider.ListOfTestData(1);
+            listOfTestClasses[0].StringColumn = LongString;
+            var tableObj = Table<TestDataType>.Create(listOfTestClasses);
+            tableObj.Columns[0].LongStringBehaviour = LongStringBehaviour.Default;
+
+            tableObj.Columns[1].Hide = true; // hide non-string fields 
+            tableObj.Columns[2].Hide = true;
+            tableObj.Columns[3].Hide = true;
+
+            // Act
+            var tableString = tableObj.ToString();
+
+            // Assert
+            string expected = "";
+            expected += "+-------------------------------------------------------------------------------------------+" + Environment.NewLine;
+            expected += "| StringColumn                                                                              |" + Environment.NewLine;
+            expected += "+-------------------------------------------------------------------------------------------+" + Environment.NewLine;
+            expected += "| Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec vehicula fringilla tortor. |" + Environment.NewLine;
+            expected += "+-------------------------------------------------------------------------------------------+";
+            tableString.ShouldBe(expected);
+        }
+
+        [Test]
+        public void TruncateBehaviourShouldNotTruncateShortString()
+        {
+            // Arrange
+            var listOfTestClasses = DataProvider.ListOfTestData(1);
+            var tableObj = Table<TestDataType>.Create(listOfTestClasses);
+            tableObj.Columns[0].LongStringBehaviour = LongStringBehaviour.Truncate;
+
+            tableObj.Columns[1].Hide = true; // hide non-string fields 
+            tableObj.Columns[2].Hide = true;
+            tableObj.Columns[3].Hide = true;
+
+            // Act
+            var tableString = tableObj.ToString();
+
+            // Assert
+            string expected = "";
+            expected += "+--------------+" + Environment.NewLine;
+            expected += "| StringColumn |" + Environment.NewLine;
+            expected += "+--------------+" + Environment.NewLine;
+            expected += "| AAAA         |" + Environment.NewLine;
+            expected += "+--------------+";
+            tableString.ShouldBe(expected);
+        }
+
+        [Test]
+        public void TruncateBehaviourShouldTruncateLongString()
+        {
+            // Arrange
+            var listOfTestClasses = DataProvider.ListOfTestData(1);
+            listOfTestClasses[0].StringColumn = LongString;
+            var tableObj = Table<TestDataType>.Create(listOfTestClasses);
+            tableObj.Columns[0].LongStringBehaviour = LongStringBehaviour.Truncate;
+
+            tableObj.Columns[1].Hide = true; // hide non-string fields 
+            tableObj.Columns[2].Hide = true;
+            tableObj.Columns[3].Hide = true;
+
+            // Act
+            var tableString = tableObj.ToString();
+
+            // Assert
+            string expected = "";
+            expected += "+-----------------+" + Environment.NewLine;
+            expected += "| StringColumn    |" + Environment.NewLine;
+            expected += "+-----------------+" + Environment.NewLine;
+            expected += "| Lorem ipsum dol |" + Environment.NewLine;
+            expected += "+-----------------+";
+            tableString.ShouldBe(expected);
+        }
+
+        [Test]
+        public void TruncateWithEllipsisBehaviourShouldTruncateLongString()
+        {
+            // Arrange
+            var listOfTestClasses = DataProvider.ListOfTestData(1);
+            listOfTestClasses[0].StringColumn = LongString;
+            var tableObj = Table<TestDataType>.Create(listOfTestClasses);
+            tableObj.Columns[0].LongStringBehaviour = LongStringBehaviour.TruncateWithEllipsis;
+
+            tableObj.Columns[1].Hide = true; // hide non-string fields 
+            tableObj.Columns[2].Hide = true;
+            tableObj.Columns[3].Hide = true;
+
+            // Act
+            var tableString = tableObj.ToString();
+
+            // Assert
+            string expected = "";
+            expected += "+-----------------+" + Environment.NewLine;
+            expected += "| StringColumn    |" + Environment.NewLine;
+            expected += "+-----------------+" + Environment.NewLine;
+            expected += "| Lorem ipsum ... |" + Environment.NewLine;
+            expected += "+-----------------+";
+            tableString.ShouldBe(expected);
+        }
+    }
+}

--- a/ConTabs.Tests/Table-Basic.cs
+++ b/ConTabs.Tests/Table-Basic.cs
@@ -3,6 +3,7 @@ using Shouldly;
 using System.Collections.Generic;
 using ConTabs.Exceptions;
 using ConTabs.TestData;
+using NUnit.Framework.Constraints;
 
 namespace ConTabs.Tests
 {
@@ -44,16 +45,31 @@ namespace ConTabs.Tests
             // Assert
             table.Columns.Count.ShouldBe(4);
         }
-        
+
         [Test]
         public void Table_GivenClassWithoutPublicProperties_ThrowsPublicPropertiesNotFoundException()
         {
             // Arrange
             var listOfTestClasses = DataProvider.ListOfInvalidTestData();
-   
+
+            // Act
+            TestDelegate testDelegate = () => Table<InvalidTestDataType>.Create(listOfTestClasses);
+
             // Assert
-            Assert.Throws<PublicPropertiesNotFoundException>(() =>
-                Table<InvalidTestDataType>.Create(listOfTestClasses));
+            Assert.Throws<PublicPropertiesNotFoundException>(testDelegate);
+        }
+
+        [Test]
+        public void Table_GivenClassWithoutPublicProperties_ThrowsExceptionWithHelpfulMessage()
+        {
+            // Arrange
+            var listOfTestClasses = DataProvider.ListOfInvalidTestData();
+
+            // Act
+            TestDelegate testDelegate = () => Table<InvalidTestDataType>.Create(listOfTestClasses);
+
+            // Assert
+            Assert.Throws<PublicPropertiesNotFoundException>(testDelegate).Message.ShouldContain("no valid properties");
         }
     }
 

--- a/ConTabs/Column.cs
+++ b/ConTabs/Column.cs
@@ -1,10 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 
 namespace ConTabs
 {
+    [DebuggerDisplay("Column for '{PropertyName}'")]
     public class Column
     {
         public Type SourceType { get; set; }

--- a/ConTabs/Column.cs
+++ b/ConTabs/Column.cs
@@ -12,7 +12,8 @@ namespace ConTabs
         public string ColumnName { get; set; }
         public string FormatString { get; set; }
         public bool Hide { get; set; }
-        
+        public LongStringBehaviour LongStringBehaviour { get; set; }
+
         public List<Object> Values { get; set; }
         public int MaxWidth => (Values == null || Values.Count() == 0 )
             ? ColumnName.Length
@@ -24,6 +25,7 @@ namespace ConTabs
         
         public Column(Type type, string name)
         {
+            LongStringBehaviour = LongStringBehaviour.Default;
             SourceType = type;
             PropertyName = name;
             ColumnName = name;
@@ -32,19 +34,26 @@ namespace ConTabs
         public string StringValForCol(Object o)
         {
             var casted = Convert.ChangeType(o, SourceType);
-            var ToStringMethod = SourceType.GetTypeInfo().DeclaredMethods.FirstOrDefault(m => 
-                m.Name == "ToString" &&
-                m.IsPublic &&
-                m.ReturnType == typeof(string) &&
-                m.GetParameters().Count() == 1 &&
-                m.GetParameters()[0].ParameterType == typeof(string));
-            if (ToStringMethod == null)
+            if (casted is string)
             {
-                return casted.ToString();
+                return LongStringBehaviour.ProcessString(casted as string);
             }
             else
             {
-                return (string)ToStringMethod.Invoke(o, new object[] { FormatString });
+                var ToStringMethod = SourceType.GetTypeInfo().DeclaredMethods.FirstOrDefault(m =>
+                    m.Name == "ToString" &&
+                    m.IsPublic &&
+                    m.ReturnType == typeof(string) &&
+                    m.GetParameters().Count() == 1 &&
+                    m.GetParameters()[0].ParameterType == typeof(string));
+                if (ToStringMethod == null)
+                {
+                    return casted.ToString();
+                }
+                else
+                {
+                    return (string)ToStringMethod.Invoke(o, new object[] { FormatString });
+                }
             }
         }
     }

--- a/ConTabs/LongStringBehaviour.cs
+++ b/ConTabs/LongStringBehaviour.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
 
 namespace ConTabs
 {
@@ -11,8 +14,9 @@ namespace ConTabs
         public static LongStringBehaviour Default => DoNothing;
 
         public static LongStringBehaviour DoNothing => new LongStringBehaviour { Method = PassThrough };
-        public static LongStringBehaviour Truncate => new LongStringBehaviour { Method = TruncateString, Width = 15};
+        public static LongStringBehaviour Truncate => new LongStringBehaviour { Method = TruncateString, Width = 15 };
         public static LongStringBehaviour TruncateWithEllipsis => new LongStringBehaviour { Method = TruncateString, EllipsisString = "...", Width = 15 };
+        public static LongStringBehaviour Wrap => new LongStringBehaviour { Method = WrapString, Width = 25 };
 
         private static string PassThrough(string input,string ellipsis, int width)
         {
@@ -26,9 +30,94 @@ namespace ConTabs
             return input.Substring(0, width - nonNullEllipsis.Length) + nonNullEllipsis;
         }
 
+        private static string WrapString(string input, string ellipsis, int width)
+        {
+            if (input.Length <= width) return input;
+            return LongStringBehaviour.WordWrap(input, width);
+        }
+
         public string ProcessString(string input)
         {
             return Method(input, EllipsisString, Width);
+        }
+
+        // The following word wrapping methods inspired by an SO answer by "ICR"
+        // https://stackoverflow.com/a/17635/50151
+
+        private static char[] splitChars = new char[] { ' ', '-', '\t' };
+
+        private static string WordWrap(string str, int width)
+        {
+            string[] words = Explode(str, splitChars);
+
+            int curLineLength = 0;
+            StringBuilder strBuilder = new StringBuilder();
+            for (int i = 0; i < words.Length; i += 1)
+            {
+                string word = words[i];
+                // If adding the new word to the current line would be too long,
+                // then put it on a new line (and split it up if it's too long).
+                if (curLineLength + word.Length > width)
+                {
+                    // Only move down to a new line if we have text on the current line.
+                    // Avoids situation where wrapped whitespace causes emptylines in text.
+                    if (curLineLength > 0)
+                    {
+                        if(splitChars.Contains(strBuilder[strBuilder.Length-1])) strBuilder.Remove(strBuilder.Length - 1, 1);
+                        strBuilder.Append(Environment.NewLine);
+                        curLineLength = 0;
+                    }
+
+                    // If the current word is too long to fit on a line even on it's own then
+                    // split the word up.
+                    while (word.Length > width)
+                    {
+                        strBuilder.Append(word.Substring(0, width - 1) + "-");
+                        word = word.Substring(width - 1);
+
+                        if (splitChars.Contains(strBuilder[strBuilder.Length - 1])) strBuilder.Remove(strBuilder.Length - 1, 1);
+                        strBuilder.Append(Environment.NewLine);
+                    }
+
+                    // Remove leading whitespace from the word so the new line starts flush to the left.
+                    word = word.TrimStart();
+                }
+                strBuilder.Append(word);
+                curLineLength += word.Length;
+            }
+
+            return strBuilder.ToString();
+        }
+
+        private static string[] Explode(string str, char[] splitChars)
+        {
+            List<string> parts = new List<string>();
+            int startIndex = 0;
+            while (true)
+            {
+                int index = str.IndexOfAny(splitChars, startIndex);
+
+                if (index == -1)
+                {
+                    parts.Add(str.Substring(startIndex));
+                    return parts.ToArray();
+                }
+
+                string word = str.Substring(startIndex, index - startIndex);
+                char nextChar = str.Substring(index, 1)[0];
+                // Dashes and the likes should stick to the word occuring before it. Whitespace doesn't have to.
+                if (char.IsWhiteSpace(nextChar))
+                {
+                    parts.Add(word);
+                    parts.Add(nextChar.ToString());
+                }
+                else
+                {
+                    parts.Add(word + nextChar);
+                }
+
+                startIndex = index + 1;
+            }
         }
     }
 }

--- a/ConTabs/LongStringBehaviour.cs
+++ b/ConTabs/LongStringBehaviour.cs
@@ -75,9 +75,6 @@ namespace ConTabs
                     {
                         strBuilder.Append(word.Substring(0, width - 1) + "-");
                         word = word.Substring(width - 1);
-
-                        if (SplitChars.Contains(strBuilder[strBuilder.Length - 1]) && strBuilder[strBuilder.Length - 1] != '-')
-                            strBuilder.Remove(strBuilder.Length - 1, 1);
                         strBuilder.Append(Environment.NewLine);
                     }
 

--- a/ConTabs/LongStringBehaviour.cs
+++ b/ConTabs/LongStringBehaviour.cs
@@ -1,0 +1,34 @@
+﻿using System;
+
+namespace ConTabs
+{
+    public class LongStringBehaviour
+    {
+        public Func<string,string,int,string> Method { get; set; }
+        public int Width { get; set; }
+        public string EllipsisString { get; set; }
+
+        public static LongStringBehaviour Default => DoNothing;
+
+        public static LongStringBehaviour DoNothing => new LongStringBehaviour { Method = PassThrough };
+        public static LongStringBehaviour Truncate => new LongStringBehaviour { Method = TruncateString, Width = 15};
+        public static LongStringBehaviour TruncateWithEllipsis => new LongStringBehaviour { Method = TruncateString, EllipsisString = "...", Width = 15 };
+
+        private static string PassThrough(string input,string ellipsis, int width)
+        {
+            return input;
+        }
+
+        private static string TruncateString(string input, string ellipsis, int width)
+        {
+            if (input.Length <= width) return input;
+            var nonNullEllipsis = ellipsis ?? "";
+            return input.Substring(0, width - nonNullEllipsis.Length) + nonNullEllipsis;
+        }
+
+        public string ProcessString(string input)
+        {
+            return Method(input, EllipsisString, Width);
+        }
+    }
+}

--- a/ConTabs/LongStringBehaviour.cs
+++ b/ConTabs/LongStringBehaviour.cs
@@ -44,11 +44,11 @@ namespace ConTabs
         // The following word wrapping methods inspired by an SO answer by "ICR"
         // https://stackoverflow.com/a/17635/50151
 
-        private static char[] splitChars = new char[] { ' ', '-', '\t' };
+        private static readonly char[] SplitChars = new char[] { ' ', '-', '\t' };
 
         private static string WordWrap(string str, int width)
         {
-            string[] words = Explode(str, splitChars);
+            string[] words = Explode(str, SplitChars);
 
             int curLineLength = 0;
             StringBuilder strBuilder = new StringBuilder();
@@ -63,7 +63,8 @@ namespace ConTabs
                     // Avoids situation where wrapped whitespace causes emptylines in text.
                     if (curLineLength > 0)
                     {
-                        if(splitChars.Contains(strBuilder[strBuilder.Length-1])) strBuilder.Remove(strBuilder.Length - 1, 1);
+                        if (SplitChars.Contains(strBuilder[strBuilder.Length - 1]) && strBuilder[strBuilder.Length - 1] != '-')
+                            strBuilder.Remove(strBuilder.Length - 1, 1);
                         strBuilder.Append(Environment.NewLine);
                         curLineLength = 0;
                     }
@@ -75,7 +76,8 @@ namespace ConTabs
                         strBuilder.Append(word.Substring(0, width - 1) + "-");
                         word = word.Substring(width - 1);
 
-                        if (splitChars.Contains(strBuilder[strBuilder.Length - 1])) strBuilder.Remove(strBuilder.Length - 1, 1);
+                        if (SplitChars.Contains(strBuilder[strBuilder.Length - 1]) && strBuilder[strBuilder.Length - 1] != '-')
+                            strBuilder.Remove(strBuilder.Length - 1, 1);
                         strBuilder.Append(Environment.NewLine);
                     }
 

--- a/ConTabs/Table.cs
+++ b/ConTabs/Table.cs
@@ -50,7 +50,7 @@ namespace ConTabs
         private Table()
         {
             TableStyle = Style.Default;
-            var props = typeof(T).GetTypeInfo().DeclaredProperties;
+            var props = GetDeclaredAndInheritedProperties(typeof(T).GetTypeInfo());
             Columns = props
                 .Where(p => p.GetMethod.IsPublic)
                 .Select(p => new Column(p.PropertyType, p.Name))
@@ -62,6 +62,20 @@ namespace ConTabs
         public override string ToString()
         {
             return OutputBuilder<T>.BuildOutput(this, TableStyle);
+        }
+
+        private static IEnumerable<PropertyInfo> GetDeclaredAndInheritedProperties(TypeInfo typeInfo)
+        {
+            // Loop down the inheritance chain finding all properties
+            while (typeInfo != null)
+            {
+                foreach (var prop in typeInfo.DeclaredProperties)
+                {
+                    yield return prop;
+                }
+
+                typeInfo = typeInfo.BaseType?.GetTypeInfo();
+            }
         }
     }
 }

--- a/ConTabs/Table.cs
+++ b/ConTabs/Table.cs
@@ -3,9 +3,11 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using ConTabs.Exceptions;
+using System.Diagnostics;
 
 namespace ConTabs
 {
+    [DebuggerDisplay("Table with {Columns.Count} available columns")]
     public partial class Table<T> where T:class
     {
         public List<Column> Columns { get; set; }

--- a/ConTabsTestData/TestData.cs
+++ b/ConTabsTestData/TestData.cs
@@ -18,6 +18,18 @@ namespace ConTabs.TestData
             return list.Take(limit.Value).ToList();
         }
 
+        public static List<ExtendedTestDataType> ListOfExtendedTestData(int? limit = null)
+        {
+            var list = new List<ExtendedTestDataType>
+            {
+                new ExtendedTestDataType{StringColumn="AAAA", IntColumn=999, CurrencyColumn=19.95M, DateTimeColumn=new DateTime(2017,01,01), CustomToString = new CustomToStringType{ StringProperty="A"} },
+                new ExtendedTestDataType{StringColumn="BB", IntColumn=1234567899, CurrencyColumn=-2000M, DateTimeColumn=new DateTime(2017,01,13), CustomToString = new CustomToStringType{ StringProperty="B"}},
+                new ExtendedTestDataType{StringColumn="CCCCCCC", IntColumn=-12, CurrencyColumn=19.95M, DateTimeColumn=new DateTime(2017,02,20), CustomToString = new CustomToStringType{ StringProperty="C"}}
+            };
+            if (!limit.HasValue || limit < 0) limit = list.Count;
+            return list.Take(limit.Value).ToList();
+        }
+
         public static List<MinimalDataType> ListOfMinimalData(int? limit = null)
         {
             var list = new List<MinimalDataType>
@@ -52,6 +64,21 @@ namespace ConTabs.TestData
         public decimal CurrencyColumn { get; set; }
         public DateTime DateTimeColumn { get; set; }
         private string HiddenProp { get; set; }
+    }
+
+    public class ExtendedTestDataType : TestDataType
+    {
+        public CustomToStringType CustomToString { get; set; }
+    }
+
+    public class CustomToStringType
+    {
+        public string StringProperty { get; set; }
+
+        public override string ToString()
+        {
+            return StringProperty;
+        }
     }
 
     public class MinimalDataType


### PR DESCRIPTION
## Long string handling
By adding a `LongStringBehaviour` property to columns, this change allows users to specify how long strings should be handled.

Users can choose from:

1. Doing nothing (default behaviour)
2. Truncating, with or without ellipsis (customisable; defaults to "...")
3. Wrapping

When truncating or wrapping, the width can also be specified.

## Minor changes
- Improved test coverage of `PublicPropertiesNotFoundException` (addressing http://bit.ly/2E4GQCg)
- Some debugging sugar in the form of `DebuggerDisplay` attributes
- Now searches base classes for public properties available through inheritance