### PR TITLE
Actually implemented wrapping of long strings

### DIFF
--- a/ConTabs.Tests/ConformanceTests.cs
+++ b/ConTabs.Tests/ConformanceTests.cs
@@ -111,6 +111,55 @@ namespace ConTabs.Tests
             expected += "CFFFFFFCFFFFFFC";
             tableString.ShouldBe(expected);
         }
+
+        [Test]
+        public void BasicTableWithWrappedStringShouldLookLikeThis()
+        {
+            // Arrange
+            var listOfTestClasses = DataProvider.ListOfTestData(1);
+            listOfTestClasses[0].StringColumn = "This string will need to be wrapped";
+            var tableObj = Table<TestDataType>.Create(listOfTestClasses);
+            tableObj.Columns[3].Hide = true; // hide date field 
+
+            // Act
+            tableObj.Columns[0].LongStringBehaviour = LongStringBehaviour.Wrap;
+            tableObj.Columns[0].LongStringBehaviour.Width = 12;
+            var tableString = tableObj.ToString();
+
+            // Assert
+            string expected = "";
+            expected += "+--------------+-----------+----------------+" + Environment.NewLine;
+            expected += "| StringColumn | IntColumn | CurrencyColumn |" + Environment.NewLine;
+            expected += "+--------------+-----------+----------------+" + Environment.NewLine;
+            expected += "| This string  | 999       | 19.95          |" + Environment.NewLine;
+            expected += "| will need to |           |                |" + Environment.NewLine;
+            expected += "| be wrapped   |           |                |" + Environment.NewLine;
+            expected += "+--------------+-----------+----------------+";
+            tableString.ShouldBe(expected);
+        }
+
+        [Test]
+        public void BasicTableWithTruncatedStringShouldLookLikeThis()
+        {
+            // Arrange
+            var listOfTestClasses = DataProvider.ListOfTestData(1);
+            listOfTestClasses[0].StringColumn = "This string will need to be wrapped";
+            var tableObj = Table<TestDataType>.Create(listOfTestClasses);
+            tableObj.Columns[3].Hide = true; // hide date field 
+
+            // Act
+            tableObj.Columns[0].LongStringBehaviour = LongStringBehaviour.TruncateWithEllipsis;
+            var tableString = tableObj.ToString();
+
+            // Assert
+            string expected = "";
+            expected += "+-----------------+-----------+----------------+" + Environment.NewLine;
+            expected += "| StringColumn    | IntColumn | CurrencyColumn |" + Environment.NewLine;
+            expected += "+-----------------+-----------+----------------+" + Environment.NewLine;
+            expected += "| This string ... | 999       | 19.95          |" + Environment.NewLine;
+            expected += "+-----------------+-----------+----------------+";
+            tableString.ShouldBe(expected);
+        }
     }
 
 }

--- a/ConTabs/Column.cs
+++ b/ConTabs/Column.cs
@@ -17,14 +17,22 @@ namespace ConTabs
         public LongStringBehaviour LongStringBehaviour { get; set; }
 
         public List<Object> Values { get; set; }
-        public int MaxWidth => (Values == null || Values.Count() == 0 )
-            ? ColumnName.Length
-            : Values
+        public int MaxWidth
+        {
+            get
+            {
+                if (Values == null || Values.Count() == 0) return ColumnName.Length;
+
+                if (LongStringBehaviour.Width > 0) return LongStringBehaviour.Width;
+
+                return Values
                 .Select(v => StringValForCol(v))
                 .Union(new List<string> { ColumnName })
                 .Select(v => v.Length)
                 .Max();
-        
+            }
+        }
+
         public Column(Type type, string name)
         {
             LongStringBehaviour = LongStringBehaviour.Default;

--- a/ConTabs/OutputBuilder.cs
+++ b/ConTabs/OutputBuilder.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 
@@ -34,7 +35,7 @@ namespace ConTabs
                 {
                     for (int i = 0; i < table.Data.Count(); i++)
                     {
-                        DataLine(i); NewLine();
+                        DataRow(i);
                     }
                 }
                 HLine(TopMidBot.Bot);
@@ -75,13 +76,25 @@ namespace ConTabs
                 }
             }
 
-            private void DataLine(int i)
+            private void DataRow(int i)
+            {
+                var cols = table._colsShown.Select(c => new CellParts(c.StringValForCol(c.Values[i]), c.MaxWidth)).ToList();
+
+                var maxLines = cols.Max(c => c.LineCount);
+
+                for (int j = 0; j < maxLines; j++)
+                {
+                    DataLine(cols, j); NewLine();
+                }
+            }
+
+            private void DataLine(List<CellParts> parts, int line)
             {
                 sb.Append(style.Wall);
-                foreach (var col in table._colsShown)
+                foreach (var part in parts)
                 {
-                    var value = col.StringValForCol(col.Values[i]);
-                    sb.Append(" " + value + new string(' ', col.MaxWidth - value.Length) + " " + style.Wall);
+                    string val = part.GetLine(line);
+                    sb.Append(" " + val + new string(' ', part.ColMaxWidth - val.Length) + " " + style.Wall);
                 }
             }
 
@@ -97,6 +110,26 @@ namespace ConTabs
                 Left,
                 Centre,
                 Right
+            }
+
+            private class CellParts
+            {
+                public CellParts(string value, int width)
+                {
+                    _value = value;
+                    ColMaxWidth = width;
+                }
+
+                public int ColMaxWidth { get; set; }
+                public int LineCount => _lines.Length;
+                public string GetLine(int i)
+                {
+                    if (_lines.Length > i) return _lines[i];
+                    return String.Empty;
+                }
+
+                private string _value { get; set; }
+                private string[] _lines => _value.Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
             }
 
             private char GetCorner(TopMidBot v, LeftCentreRight h)


### PR DESCRIPTION
Although v0.3 has a method to wrap strings (which is tested and works), the `OutputBuilder` lacked multiline awareness. This fixes that and makes the long string wrapping useful.