### PR TITLE
Issue #15 - Allow for alignment of data in columns to be controlled

### DIFF
--- a/ConTabs.Tests/AlignmentTests.cs
+++ b/ConTabs.Tests/AlignmentTests.cs
@@ -14,115 +14,115 @@ namespace ConTabs.Tests
             var listOfTestClasses = DataProvider.ListOfTestData(1);
             var tableObj = Table<TestDataType>.Create(listOfTestClasses);
 
-			// Act
-			// Assert
-			var leftAlignedColumns = tableObj.Columns.FindAll(c => c.Alignment == Alignment.Left);
-			leftAlignedColumns.Count.ShouldBe(tableObj.Columns.Count);
+            // Act
+            // Assert
+            var leftAlignedColumns = tableObj.Columns.FindAll(c => c.Alignment == Alignment.Left);
+            leftAlignedColumns.Count.ShouldBe(tableObj.Columns.Count);
         }
 
-		[Test]
-		public void DefaultHeaderAlignmentShouldBeLeft()
-		{
-			// Arrange
-			var listOfTestClasses = DataProvider.ListOfTestData(1);
-			var tableObj = Table<TestDataType>.Create(listOfTestClasses);
+        [Test]
+        public void DefaultHeaderAlignmentShouldBeLeft()
+        {
+            // Arrange
+            var listOfTestClasses = DataProvider.ListOfTestData(1);
+            var tableObj = Table<TestDataType>.Create(listOfTestClasses);
 
-			// Act
-			// Assert
-			tableObj.HeaderAlignment.ShouldBe(Alignment.Left);
-		}
+            // Act
+            // Assert
+            tableObj.HeaderAlignment.ShouldBe(Alignment.Left);
+        }
 
-		[Test]
-		public void SettingColumnAlignmentShouldSetAllColumnAlignments()
-		{
-			// Arrange
-			var listOfTestClasses = DataProvider.ListOfTestData(1);
-			var tableObj = Table<TestDataType>.Create(listOfTestClasses);
+        [Test]
+        public void SettingColumnAlignmentShouldSetAllColumnAlignments()
+        {
+            // Arrange
+            var listOfTestClasses = DataProvider.ListOfTestData(1);
+            var tableObj = Table<TestDataType>.Create(listOfTestClasses);
 
-			// Act
-			tableObj.ColumnAlignment = Alignment.Right;
+            // Act
+            tableObj.ColumnAlignment = Alignment.Right;
 
-			// Assert
-			var rightAlignedColumns = tableObj.Columns.FindAll(c => c.Alignment == Alignment.Right);
-			rightAlignedColumns.Count.ShouldBe(tableObj.Columns.Count);
-		}
+            // Assert
+            var rightAlignedColumns = tableObj.Columns.FindAll(c => c.Alignment == Alignment.Right);
+            rightAlignedColumns.Count.ShouldBe(tableObj.Columns.Count);
+        }
 
-		[Test]
-		public void SettingIndividualColumnAlignmentShouldOverwriteTableColumnAlignment()
-		{
-			// Arrange
-			var listOfTestClasses = DataProvider.ListOfTestData(1);
-			var tableObj = Table<TestDataType>.Create(listOfTestClasses);
+        [Test]
+        public void SettingIndividualColumnAlignmentShouldOverwriteTableColumnAlignment()
+        {
+            // Arrange
+            var listOfTestClasses = DataProvider.ListOfTestData(1);
+            var tableObj = Table<TestDataType>.Create(listOfTestClasses);
 
-			// Act
-			tableObj.ColumnAlignment = Alignment.Right;
-			tableObj.Columns[1].Alignment = Alignment.Center;
+            // Act
+            tableObj.ColumnAlignment = Alignment.Right;
+            tableObj.Columns[1].Alignment = Alignment.Center;
 
-			// Assert
-			tableObj.Columns[0].Alignment.ShouldBe(Alignment.Right);
-			tableObj.Columns[1].Alignment.ShouldBe(Alignment.Center);
-			tableObj.Columns[2].Alignment.ShouldBe(Alignment.Right);
-			tableObj.Columns[3].Alignment.ShouldBe(Alignment.Right);
-		}
+            // Assert
+            tableObj.Columns[0].Alignment.ShouldBe(Alignment.Right);
+            tableObj.Columns[1].Alignment.ShouldBe(Alignment.Center);
+            tableObj.Columns[2].Alignment.ShouldBe(Alignment.Right);
+            tableObj.Columns[3].Alignment.ShouldBe(Alignment.Right);
+        }
 
-		[Test]
-		public void LeftAlignmentShouldLookLikeThis()
-		{
-			// Arrange
-			var input = "My input";
-			var colMaxWidth = 12;
-			var alignment = new Alignment() { Method = Alignment.Left.Method };
+        [Test]
+        public void LeftAlignmentShouldLookLikeThis()
+        {
+            // Arrange
+            var input = "My input";
+            var colMaxWidth = 12;
+            var alignment = new Alignment() { Method = Alignment.Left.Method };
 
-			// Act
-			var result = alignment.ProcessString(input, colMaxWidth);
+            // Act
+            var result = alignment.ProcessString(input, colMaxWidth);
 
-			// Assert
-			result.ShouldBe("My input    ");
-		}
+            // Assert
+            result.ShouldBe("My input    ");
+        }
 
-		[Test]
-		public void RightAlignmentShouldLookLikeThis()
-		{
-			// Arrange
-			var input = "My input";
-			var colMaxWidth = 12;
-			var alignment = new Alignment() { Method = Alignment.Right.Method };
+        [Test]
+        public void RightAlignmentShouldLookLikeThis()
+        {
+            // Arrange
+            var input = "My input";
+            var colMaxWidth = 12;
+            var alignment = new Alignment() { Method = Alignment.Right.Method };
 
-			// Act
-			var result = alignment.ProcessString(input, colMaxWidth);
+            // Act
+            var result = alignment.ProcessString(input, colMaxWidth);
 
-			// Assert
-			result.ShouldBe("    My input");
-		}
+            // Assert
+            result.ShouldBe("    My input");
+        }
 
-		[Test]
-		public void CenterAlignmentWithEvenColumnMaxWidthShouldLookLikeThis()
-		{
-			// Arrange
-			var input = "My input";
-			var colMaxWidth = 12;
-			var alignment = new Alignment() { Method = Alignment.Center.Method };
+        [Test]
+        public void CenterAlignmentWithEvenColumnMaxWidthShouldLookLikeThis()
+        {
+            // Arrange
+            var input = "My input";
+            var colMaxWidth = 12;
+            var alignment = new Alignment() { Method = Alignment.Center.Method };
 
-			// Act
-			var result = alignment.ProcessString(input, colMaxWidth);
+            // Act
+            var result = alignment.ProcessString(input, colMaxWidth);
 
-			// Assert
-			result.ShouldBe("  My input  ");
-		}
+            // Assert
+            result.ShouldBe("  My input  ");
+        }
 
-		[Test]
-		public void CenterAlignmentWithOddColumnMaxWidthShouldLookLikeThis()
-		{
-			// Arrange
-			var input = "My input";
-			var colMaxWidth = 13;
-			var alignment = new Alignment() { Method = Alignment.Center.Method };
+        [Test]
+        public void CenterAlignmentWithOddColumnMaxWidthShouldLookLikeThis()
+        {
+            // Arrange
+            var input = "My input";
+            var colMaxWidth = 13;
+            var alignment = new Alignment() { Method = Alignment.Center.Method };
 
-			// Act
-			var result = alignment.ProcessString(input, colMaxWidth);
+            // Act
+            var result = alignment.ProcessString(input, colMaxWidth);
 
-			// Assert
-			result.ShouldBe("  My input   ");
-		}
-	}
+            // Assert
+            result.ShouldBe("  My input   ");
+        }
+    }
 }

--- a/ConTabs.Tests/AlignmentTests.cs
+++ b/ConTabs.Tests/AlignmentTests.cs
@@ -1,0 +1,68 @@
+﻿using ConTabs.TestData;
+using NUnit.Framework;
+using Shouldly;
+
+namespace ConTabs.Tests
+{
+    [TestFixture]
+    public class AlignmentTests
+    {
+        [Test]
+        public void DefaultColumnAlignmentShouldBeLeft()
+        {
+            // Arrange
+            var listOfTestClasses = DataProvider.ListOfTestData(1);
+            var tableObj = Table<TestDataType>.Create(listOfTestClasses);
+
+			// Act
+			// Assert
+			var leftAlignedColumns = tableObj.Columns.FindAll(c => c.Alignment == Alignment.Left);
+			leftAlignedColumns.Count.ShouldBe(tableObj.Columns.Count);
+        }
+
+		[Test]
+		public void DefaultHeaderAlignmentShouldBeLeft()
+		{
+			// Arrange
+			var listOfTestClasses = DataProvider.ListOfTestData(1);
+			var tableObj = Table<TestDataType>.Create(listOfTestClasses);
+
+			// Act
+			// Assert
+			tableObj.HeaderAlignment.ShouldBe(Alignment.Left);
+		}
+
+		[Test]
+		public void SettingColumnAlignmentShouldSetAllColumnAlignments()
+		{
+			// Arrange
+			var listOfTestClasses = DataProvider.ListOfTestData(1);
+			var tableObj = Table<TestDataType>.Create(listOfTestClasses);
+
+			// Act
+			tableObj.ColumnAlignment = Alignment.Right;
+
+			// Assert
+			var rightAlignedColumns = tableObj.Columns.FindAll(c => c.Alignment == Alignment.Right);
+			rightAlignedColumns.Count.ShouldBe(tableObj.Columns.Count);
+		}
+
+		[Test]
+		public void SettingIndividualColumnAlignmentShouldOverwriteTableColumnAlignment()
+		{
+			// Arrange
+			var listOfTestClasses = DataProvider.ListOfTestData(1);
+			var tableObj = Table<TestDataType>.Create(listOfTestClasses);
+
+			// Act
+			tableObj.ColumnAlignment = Alignment.Right;
+			tableObj.Columns[1].Alignment = Alignment.Center;
+
+			// Assert
+			tableObj.Columns[0].Alignment.ShouldBe(Alignment.Right);
+			tableObj.Columns[1].Alignment.ShouldBe(Alignment.Center);
+			tableObj.Columns[2].Alignment.ShouldBe(Alignment.Right);
+			tableObj.Columns[3].Alignment.ShouldBe(Alignment.Right);
+		}
+	}
+}

--- a/ConTabs.Tests/AlignmentTests.cs
+++ b/ConTabs.Tests/AlignmentTests.cs
@@ -64,5 +64,65 @@ namespace ConTabs.Tests
 			tableObj.Columns[2].Alignment.ShouldBe(Alignment.Right);
 			tableObj.Columns[3].Alignment.ShouldBe(Alignment.Right);
 		}
+
+		[Test]
+		public void LeftAlignmentShouldLookLikeThis()
+		{
+			// Arrange
+			var input = "My input";
+			var colMaxWidth = 12;
+			var alignment = new Alignment() { Method = Alignment.Left.Method };
+
+			// Act
+			var result = alignment.ProcessString(input, colMaxWidth);
+
+			// Assert
+			result.ShouldBe("My input    ");
+		}
+
+		[Test]
+		public void RightAlignmentShouldLookLikeThis()
+		{
+			// Arrange
+			var input = "My input";
+			var colMaxWidth = 12;
+			var alignment = new Alignment() { Method = Alignment.Right.Method };
+
+			// Act
+			var result = alignment.ProcessString(input, colMaxWidth);
+
+			// Assert
+			result.ShouldBe("    My input");
+		}
+
+		[Test]
+		public void CenterAlignmentWithEvenColumnMaxWidthShouldLookLikeThis()
+		{
+			// Arrange
+			var input = "My input";
+			var colMaxWidth = 12;
+			var alignment = new Alignment() { Method = Alignment.Center.Method };
+
+			// Act
+			var result = alignment.ProcessString(input, colMaxWidth);
+
+			// Assert
+			result.ShouldBe("  My input  ");
+		}
+
+		[Test]
+		public void CenterAlignmentWithOddColumnMaxWidthShouldLookLikeThis()
+		{
+			// Arrange
+			var input = "My input";
+			var colMaxWidth = 13;
+			var alignment = new Alignment() { Method = Alignment.Center.Method };
+
+			// Act
+			var result = alignment.ProcessString(input, colMaxWidth);
+
+			// Assert
+			result.ShouldBe("  My input   ");
+		}
 	}
 }

--- a/ConTabs.Tests/ConTabs.Tests.csproj
+++ b/ConTabs.Tests/ConTabs.Tests.csproj
@@ -51,6 +51,7 @@
   <ItemGroup>
     <Compile Include="ConformanceTests.cs" />
     <Compile Include="FormatTests.cs" />
+    <Compile Include="AlignmentTests.cs" />
     <Compile Include="Table-Basic.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="LongStringBehaviourTests.cs" />

--- a/ConTabs.Tests/ConformanceTests.cs
+++ b/ConTabs.Tests/ConformanceTests.cs
@@ -249,7 +249,7 @@ namespace ConTabs.Tests
 			expected += "+--------------+-----------+----------------+" + Environment.NewLine;
 			expected += "| StringColumn | IntColumn | CurrencyColumn |" + Environment.NewLine;
 			expected += "+--------------+-----------+----------------+" + Environment.NewLine;
-			expected += "|  This string | 999       | 19.95          |" + Environment.NewLine;
+			expected += "| This string  | 999       | 19.95          |" + Environment.NewLine;
 			expected += "| will need to |           |                |" + Environment.NewLine;
 			expected += "|  be wrapped  |           |                |" + Environment.NewLine;
 			expected += "+--------------+-----------+----------------+";
@@ -318,7 +318,7 @@ namespace ConTabs.Tests
 			expected += "+--------------+-----------+----------------+" + Environment.NewLine;
 			expected += "| StringColumn | IntColumn | CurrencyColumn |" + Environment.NewLine;
 			expected += "+--------------+-----------+----------------+" + Environment.NewLine;
-			expected += "|     AAAA     |    999    |      19.95     |" + Environment.NewLine;
+			expected += "|     AAAA     |    999    |     19.95      |" + Environment.NewLine;
 			expected += "+--------------+-----------+----------------+";
 			tableString.ShouldBe(expected);
 		}
@@ -362,7 +362,7 @@ namespace ConTabs.Tests
 			// Assert
 			string expected = "";
 			expected += "+---------------------------+-----------+----------------+" + Environment.NewLine;
-			expected += "|        StringColumn       | IntColumn | CurrencyColumn |" + Environment.NewLine;
+			expected += "|       StringColumn        | IntColumn | CurrencyColumn |" + Environment.NewLine;
 			expected += "+---------------------------+-----------+----------------+" + Environment.NewLine;
 			expected += "| Longer than header string | 999       | 19.95          |" + Environment.NewLine;
 			expected += "+---------------------------+-----------+----------------+";
@@ -385,7 +385,7 @@ namespace ConTabs.Tests
 			// Assert
 			string expected = "";
 			expected += "+---------------------------+-----------+----------------+" + Environment.NewLine;
-			expected += "|        StringColumn       | IntColumn | CurrencyColumn |" + Environment.NewLine;
+			expected += "|       StringColumn        | IntColumn | CurrencyColumn |" + Environment.NewLine;
 			expected += "+---------------------------+-----------+----------------+" + Environment.NewLine;
 			expected += "| Longer than header string | 999       | 19.95          |" + Environment.NewLine;
 			expected += "+---------------------------+-----------+----------------+";

--- a/ConTabs.Tests/ConformanceTests.cs
+++ b/ConTabs.Tests/ConformanceTests.cs
@@ -49,29 +49,29 @@ namespace ConTabs.Tests
             tableString.ShouldBe(expected);
         }
 
-		[Test]
-		public void BasicTableWithOneLineOfDataAndEmptyStringValueShouldLookLikeThis()
-		{
-			// Arrange
-			var listOfTestClasses = DataProvider.ListOfTestData(1);
-			listOfTestClasses[0].StringColumn = string.Empty;
-			var tableObj = Table<TestDataType>.Create(listOfTestClasses);
-			tableObj.Columns[3].Hide = true; // hide date field 
+        [Test]
+        public void BasicTableWithOneLineOfDataAndEmptyStringValueShouldLookLikeThis()
+        {
+            // Arrange
+            var listOfTestClasses = DataProvider.ListOfTestData(1);
+            listOfTestClasses[0].StringColumn = string.Empty;
+            var tableObj = Table<TestDataType>.Create(listOfTestClasses);
+            tableObj.Columns[3].Hide = true; // hide date field 
 
-			// Act
-			var tableString = tableObj.ToString();
+            // Act
+            var tableString = tableObj.ToString();
 
-			// Assert
-			string expected = "";
-			expected += "+--------------+-----------+----------------+" + Environment.NewLine;
-			expected += "| StringColumn | IntColumn | CurrencyColumn |" + Environment.NewLine;
-			expected += "+--------------+-----------+----------------+" + Environment.NewLine;
-			expected += "|              | 999       | 19.95          |" + Environment.NewLine;
-			expected += "+--------------+-----------+----------------+";
-			tableString.ShouldBe(expected);
-		}
+            // Assert
+            string expected = "";
+            expected += "+--------------+-----------+----------------+" + Environment.NewLine;
+            expected += "| StringColumn | IntColumn | CurrencyColumn |" + Environment.NewLine;
+            expected += "+--------------+-----------+----------------+" + Environment.NewLine;
+            expected += "|              | 999       | 19.95          |" + Environment.NewLine;
+            expected += "+--------------+-----------+----------------+";
+            tableString.ShouldBe(expected);
+        }
 
-		[Test]
+        [Test]
         public void TableStyledAsUnicodePipesShouldLookLikeThis()
         {
             // Arrange
@@ -202,61 +202,61 @@ namespace ConTabs.Tests
             tableString.ShouldBe(expected);
         }
 
-		[Test]
-		public void BasicTableWithWrappedStringAndRightAlignmentShouldLookLikeThis()
-		{
-			// Arrange
-			var listOfTestClasses = DataProvider.ListOfTestData(1);
-			listOfTestClasses[0].StringColumn = "This string will need to be wrapped";
-			var tableObj = Table<TestDataType>.Create(listOfTestClasses);
-			tableObj.Columns[3].Hide = true; // hide date field 
+        [Test]
+        public void BasicTableWithWrappedStringAndRightAlignmentShouldLookLikeThis()
+        {
+            // Arrange
+            var listOfTestClasses = DataProvider.ListOfTestData(1);
+            listOfTestClasses[0].StringColumn = "This string will need to be wrapped";
+            var tableObj = Table<TestDataType>.Create(listOfTestClasses);
+            tableObj.Columns[3].Hide = true; // hide date field 
 
-			// Act
-			tableObj.Columns[0].LongStringBehaviour = LongStringBehaviour.Wrap;
-			tableObj.Columns[0].LongStringBehaviour.Width = 12;
-			tableObj.Columns[0].Alignment = Alignment.Right;
-			var tableString = tableObj.ToString();
+            // Act
+            tableObj.Columns[0].LongStringBehaviour = LongStringBehaviour.Wrap;
+            tableObj.Columns[0].LongStringBehaviour.Width = 12;
+            tableObj.Columns[0].Alignment = Alignment.Right;
+            var tableString = tableObj.ToString();
 
-			// Assert
-			string expected = "";
-			expected += "+--------------+-----------+----------------+" + Environment.NewLine;
-			expected += "| StringColumn | IntColumn | CurrencyColumn |" + Environment.NewLine;
-			expected += "+--------------+-----------+----------------+" + Environment.NewLine;
-			expected += "|  This string | 999       | 19.95          |" + Environment.NewLine;
-			expected += "| will need to |           |                |" + Environment.NewLine;
-			expected += "|   be wrapped |           |                |" + Environment.NewLine;
-			expected += "+--------------+-----------+----------------+";
-			tableString.ShouldBe(expected);
-		}
+            // Assert
+            string expected = "";
+            expected += "+--------------+-----------+----------------+" + Environment.NewLine;
+            expected += "| StringColumn | IntColumn | CurrencyColumn |" + Environment.NewLine;
+            expected += "+--------------+-----------+----------------+" + Environment.NewLine;
+            expected += "|  This string | 999       | 19.95          |" + Environment.NewLine;
+            expected += "| will need to |           |                |" + Environment.NewLine;
+            expected += "|   be wrapped |           |                |" + Environment.NewLine;
+            expected += "+--------------+-----------+----------------+";
+            tableString.ShouldBe(expected);
+        }
 
-		[Test]
-		public void BasicTableWithWrappedStringAndCenterAlignmentShouldLookLikeThis()
-		{
-			// Arrange
-			var listOfTestClasses = DataProvider.ListOfTestData(1);
-			listOfTestClasses[0].StringColumn = "This string will need to be wrapped";
-			var tableObj = Table<TestDataType>.Create(listOfTestClasses);
-			tableObj.Columns[3].Hide = true; // hide date field 
+        [Test]
+        public void BasicTableWithWrappedStringAndCenterAlignmentShouldLookLikeThis()
+        {
+            // Arrange
+            var listOfTestClasses = DataProvider.ListOfTestData(1);
+            listOfTestClasses[0].StringColumn = "This string will need to be wrapped";
+            var tableObj = Table<TestDataType>.Create(listOfTestClasses);
+            tableObj.Columns[3].Hide = true; // hide date field 
 
-			// Act
-			tableObj.Columns[0].LongStringBehaviour = LongStringBehaviour.Wrap;			
-			tableObj.Columns[0].LongStringBehaviour.Width = 12;
-			tableObj.Columns[0].Alignment = Alignment.Center;
-			var tableString = tableObj.ToString();
+            // Act
+            tableObj.Columns[0].LongStringBehaviour = LongStringBehaviour.Wrap;			
+            tableObj.Columns[0].LongStringBehaviour.Width = 12;
+            tableObj.Columns[0].Alignment = Alignment.Center;
+            var tableString = tableObj.ToString();
 
-			// Assert
-			string expected = "";
-			expected += "+--------------+-----------+----------------+" + Environment.NewLine;
-			expected += "| StringColumn | IntColumn | CurrencyColumn |" + Environment.NewLine;
-			expected += "+--------------+-----------+----------------+" + Environment.NewLine;
-			expected += "| This string  | 999       | 19.95          |" + Environment.NewLine;
-			expected += "| will need to |           |                |" + Environment.NewLine;
-			expected += "|  be wrapped  |           |                |" + Environment.NewLine;
-			expected += "+--------------+-----------+----------------+";
-			tableString.ShouldBe(expected);
-		}
+            // Assert
+            string expected = "";
+            expected += "+--------------+-----------+----------------+" + Environment.NewLine;
+            expected += "| StringColumn | IntColumn | CurrencyColumn |" + Environment.NewLine;
+            expected += "+--------------+-----------+----------------+" + Environment.NewLine;
+            expected += "| This string  | 999       | 19.95          |" + Environment.NewLine;
+            expected += "| will need to |           |                |" + Environment.NewLine;
+            expected += "|  be wrapped  |           |                |" + Environment.NewLine;
+            expected += "+--------------+-----------+----------------+";
+            tableString.ShouldBe(expected);
+        }
 
-		[Test]
+        [Test]
         public void BasicTableWithTruncatedStringShouldLookLikeThis()
         {
             // Arrange
@@ -279,94 +279,94 @@ namespace ConTabs.Tests
             tableString.ShouldBe(expected);
         }
 
-		[Test]
-		public void BasicTableWithRightColumnAlignmentShouldLookLikeThis()
-		{
-			// Arrange
-			var listOfTestClasses = DataProvider.ListOfTestData(1);
-			var tableObj = Table<TestDataType>.Create(listOfTestClasses);
-			tableObj.Columns[3].Hide = true; // hide date field 
+        [Test]
+        public void BasicTableWithRightColumnAlignmentShouldLookLikeThis()
+        {
+            // Arrange
+            var listOfTestClasses = DataProvider.ListOfTestData(1);
+            var tableObj = Table<TestDataType>.Create(listOfTestClasses);
+            tableObj.Columns[3].Hide = true; // hide date field 
 
-			// Act
-			tableObj.ColumnAlignment = Alignment.Right;
-			var tableString = tableObj.ToString();
+            // Act
+            tableObj.ColumnAlignment = Alignment.Right;
+            var tableString = tableObj.ToString();
 
-			// Assert
-			string expected = "";
-			expected += "+--------------+-----------+----------------+" + Environment.NewLine;
-			expected += "| StringColumn | IntColumn | CurrencyColumn |" + Environment.NewLine;
-			expected += "+--------------+-----------+----------------+" + Environment.NewLine;
-			expected += "|         AAAA |       999 |          19.95 |" + Environment.NewLine;
-			expected += "+--------------+-----------+----------------+";
-			tableString.ShouldBe(expected);
-		}
+            // Assert
+            string expected = "";
+            expected += "+--------------+-----------+----------------+" + Environment.NewLine;
+            expected += "| StringColumn | IntColumn | CurrencyColumn |" + Environment.NewLine;
+            expected += "+--------------+-----------+----------------+" + Environment.NewLine;
+            expected += "|         AAAA |       999 |          19.95 |" + Environment.NewLine;
+            expected += "+--------------+-----------+----------------+";
+            tableString.ShouldBe(expected);
+        }
 
-		[Test]
-		public void BasicTableWithCenterColumnAlignmentShouldLookLikeThis()
-		{
-			// Arrange
-			var listOfTestClasses = DataProvider.ListOfTestData(1);
-			var tableObj = Table<TestDataType>.Create(listOfTestClasses);
-			tableObj.Columns[3].Hide = true; // hide date field 
+        [Test]
+        public void BasicTableWithCenterColumnAlignmentShouldLookLikeThis()
+        {
+            // Arrange
+            var listOfTestClasses = DataProvider.ListOfTestData(1);
+            var tableObj = Table<TestDataType>.Create(listOfTestClasses);
+            tableObj.Columns[3].Hide = true; // hide date field 
 
-			// Act
-			tableObj.ColumnAlignment = Alignment.Center;
-			var tableString = tableObj.ToString();
+            // Act
+            tableObj.ColumnAlignment = Alignment.Center;
+            var tableString = tableObj.ToString();
 
-			// Assert
-			string expected = "";
-			expected += "+--------------+-----------+----------------+" + Environment.NewLine;
-			expected += "| StringColumn | IntColumn | CurrencyColumn |" + Environment.NewLine;
-			expected += "+--------------+-----------+----------------+" + Environment.NewLine;
-			expected += "|     AAAA     |    999    |     19.95      |" + Environment.NewLine;
-			expected += "+--------------+-----------+----------------+";
-			tableString.ShouldBe(expected);
-		}
+            // Assert
+            string expected = "";
+            expected += "+--------------+-----------+----------------+" + Environment.NewLine;
+            expected += "| StringColumn | IntColumn | CurrencyColumn |" + Environment.NewLine;
+            expected += "+--------------+-----------+----------------+" + Environment.NewLine;
+            expected += "|     AAAA     |    999    |     19.95      |" + Environment.NewLine;
+            expected += "+--------------+-----------+----------------+";
+            tableString.ShouldBe(expected);
+        }
 
-		[Test]
-		public void BasicTableWithRightHeaderAlignmentShouldLookLikeThis()
-		{
-			// Arrange
-			var listOfTestClasses = DataProvider.ListOfTestData(1);
-			listOfTestClasses[0].StringColumn = "Longer than header string";
-			var tableObj = Table<TestDataType>.Create(listOfTestClasses);
-			tableObj.Columns[3].Hide = true; // hide date field 
+        [Test]
+        public void BasicTableWithRightHeaderAlignmentShouldLookLikeThis()
+        {
+            // Arrange
+            var listOfTestClasses = DataProvider.ListOfTestData(1);
+            listOfTestClasses[0].StringColumn = "Longer than header string";
+            var tableObj = Table<TestDataType>.Create(listOfTestClasses);
+            tableObj.Columns[3].Hide = true; // hide date field 
 
-			// Act
-			tableObj.HeaderAlignment = Alignment.Right;
-			var tableString = tableObj.ToString();
+            // Act
+            tableObj.HeaderAlignment = Alignment.Right;
+            var tableString = tableObj.ToString();
 
-			// Assert
-			string expected = "";
-			expected += "+---------------------------+-----------+----------------+" + Environment.NewLine;
-			expected += "|              StringColumn | IntColumn | CurrencyColumn |" + Environment.NewLine;
-			expected += "+---------------------------+-----------+----------------+" + Environment.NewLine;
-			expected += "| Longer than header string | 999       | 19.95          |" + Environment.NewLine;
-			expected += "+---------------------------+-----------+----------------+";
-			tableString.ShouldBe(expected);
-		}
+            // Assert
+            string expected = "";
+            expected += "+---------------------------+-----------+----------------+" + Environment.NewLine;
+            expected += "|              StringColumn | IntColumn | CurrencyColumn |" + Environment.NewLine;
+            expected += "+---------------------------+-----------+----------------+" + Environment.NewLine;
+            expected += "| Longer than header string | 999       | 19.95          |" + Environment.NewLine;
+            expected += "+---------------------------+-----------+----------------+";
+            tableString.ShouldBe(expected);
+        }
 
-		[Test]
-		public void BasicTableWithCenterHeaderAlignmentShouldLookLikeThis()
-		{
-			// Arrange
-			var listOfTestClasses = DataProvider.ListOfTestData(1);
-			listOfTestClasses[0].StringColumn = "Longer than header string";
-			var tableObj = Table<TestDataType>.Create(listOfTestClasses);
-			tableObj.Columns[3].Hide = true; // hide date field 
+        [Test]
+        public void BasicTableWithCenterHeaderAlignmentShouldLookLikeThis()
+        {
+            // Arrange
+            var listOfTestClasses = DataProvider.ListOfTestData(1);
+            listOfTestClasses[0].StringColumn = "Longer than header string";
+            var tableObj = Table<TestDataType>.Create(listOfTestClasses);
+            tableObj.Columns[3].Hide = true; // hide date field 
 
-			// Act
-			tableObj.HeaderAlignment = Alignment.Center;
-			var tableString = tableObj.ToString();
+            // Act
+            tableObj.HeaderAlignment = Alignment.Center;
+            var tableString = tableObj.ToString();
 
-			// Assert
-			string expected = "";
-			expected += "+---------------------------+-----------+----------------+" + Environment.NewLine;
-			expected += "|       StringColumn        | IntColumn | CurrencyColumn |" + Environment.NewLine;
-			expected += "+---------------------------+-----------+----------------+" + Environment.NewLine;
-			expected += "| Longer than header string | 999       | 19.95          |" + Environment.NewLine;
-			expected += "+---------------------------+-----------+----------------+";
-			tableString.ShouldBe(expected);
-		}
-	}
+            // Assert
+            string expected = "";
+            expected += "+---------------------------+-----------+----------------+" + Environment.NewLine;
+            expected += "|       StringColumn        | IntColumn | CurrencyColumn |" + Environment.NewLine;
+            expected += "+---------------------------+-----------+----------------+" + Environment.NewLine;
+            expected += "| Longer than header string | 999       | 19.95          |" + Environment.NewLine;
+            expected += "+---------------------------+-----------+----------------+";
+            tableString.ShouldBe(expected);
+        }
+    }
 }

--- a/ConTabs.Tests/ConformanceTests.cs
+++ b/ConTabs.Tests/ConformanceTests.cs
@@ -49,7 +49,29 @@ namespace ConTabs.Tests
             tableString.ShouldBe(expected);
         }
 
-        [Test]
+		[Test]
+		public void BasicTableWithOneLineOfDataAndEmptyStringValueShouldLookLikeThis()
+		{
+			// Arrange
+			var listOfTestClasses = DataProvider.ListOfTestData(1);
+			listOfTestClasses[0].StringColumn = string.Empty;
+			var tableObj = Table<TestDataType>.Create(listOfTestClasses);
+			tableObj.Columns[3].Hide = true; // hide date field 
+
+			// Act
+			var tableString = tableObj.ToString();
+
+			// Assert
+			string expected = "";
+			expected += "+--------------+-----------+----------------+" + Environment.NewLine;
+			expected += "| StringColumn | IntColumn | CurrencyColumn |" + Environment.NewLine;
+			expected += "+--------------+-----------+----------------+" + Environment.NewLine;
+			expected += "|              | 999       | 19.95          |" + Environment.NewLine;
+			expected += "+--------------+-----------+----------------+";
+			tableString.ShouldBe(expected);
+		}
+
+		[Test]
         public void TableStyledAsUnicodePipesShouldLookLikeThis()
         {
             // Arrange
@@ -180,7 +202,61 @@ namespace ConTabs.Tests
             tableString.ShouldBe(expected);
         }
 
-        [Test]
+		[Test]
+		public void BasicTableWithWrappedStringAndRightAlignmentShouldLookLikeThis()
+		{
+			// Arrange
+			var listOfTestClasses = DataProvider.ListOfTestData(1);
+			listOfTestClasses[0].StringColumn = "This string will need to be wrapped";
+			var tableObj = Table<TestDataType>.Create(listOfTestClasses);
+			tableObj.Columns[3].Hide = true; // hide date field 
+
+			// Act
+			tableObj.Columns[0].LongStringBehaviour = LongStringBehaviour.Wrap;
+			tableObj.Columns[0].LongStringBehaviour.Width = 12;
+			tableObj.Columns[0].Alignment = Alignment.Right;
+			var tableString = tableObj.ToString();
+
+			// Assert
+			string expected = "";
+			expected += "+--------------+-----------+----------------+" + Environment.NewLine;
+			expected += "| StringColumn | IntColumn | CurrencyColumn |" + Environment.NewLine;
+			expected += "+--------------+-----------+----------------+" + Environment.NewLine;
+			expected += "|  This string | 999       | 19.95          |" + Environment.NewLine;
+			expected += "| will need to |           |                |" + Environment.NewLine;
+			expected += "|   be wrapped |           |                |" + Environment.NewLine;
+			expected += "+--------------+-----------+----------------+";
+			tableString.ShouldBe(expected);
+		}
+
+		[Test]
+		public void BasicTableWithWrappedStringAndCenterAlignmentShouldLookLikeThis()
+		{
+			// Arrange
+			var listOfTestClasses = DataProvider.ListOfTestData(1);
+			listOfTestClasses[0].StringColumn = "This string will need to be wrapped";
+			var tableObj = Table<TestDataType>.Create(listOfTestClasses);
+			tableObj.Columns[3].Hide = true; // hide date field 
+
+			// Act
+			tableObj.Columns[0].LongStringBehaviour = LongStringBehaviour.Wrap;			
+			tableObj.Columns[0].LongStringBehaviour.Width = 12;
+			tableObj.Columns[0].Alignment = Alignment.Center;
+			var tableString = tableObj.ToString();
+
+			// Assert
+			string expected = "";
+			expected += "+--------------+-----------+----------------+" + Environment.NewLine;
+			expected += "| StringColumn | IntColumn | CurrencyColumn |" + Environment.NewLine;
+			expected += "+--------------+-----------+----------------+" + Environment.NewLine;
+			expected += "|  This string | 999       | 19.95          |" + Environment.NewLine;
+			expected += "| will need to |           |                |" + Environment.NewLine;
+			expected += "|  be wrapped  |           |                |" + Environment.NewLine;
+			expected += "+--------------+-----------+----------------+";
+			tableString.ShouldBe(expected);
+		}
+
+		[Test]
         public void BasicTableWithTruncatedStringShouldLookLikeThis()
         {
             // Arrange
@@ -202,6 +278,119 @@ namespace ConTabs.Tests
             expected += "+-----------------+-----------+----------------+";
             tableString.ShouldBe(expected);
         }
-    }
+
+		[Test]
+		public void BasicTableWithRightColumnAlignmentShouldLookLikeThis()
+		{
+			// Arrange
+			var listOfTestClasses = DataProvider.ListOfTestData(1);
+			var tableObj = Table<TestDataType>.Create(listOfTestClasses);
+			tableObj.Columns[3].Hide = true; // hide date field 
+
+			// Act
+			tableObj.ColumnAlignment = Alignment.Right;
+			var tableString = tableObj.ToString();
+
+			// Assert
+			string expected = "";
+			expected += "+--------------+-----------+----------------+" + Environment.NewLine;
+			expected += "| StringColumn | IntColumn | CurrencyColumn |" + Environment.NewLine;
+			expected += "+--------------+-----------+----------------+" + Environment.NewLine;
+			expected += "|         AAAA |       999 |          19.95 |" + Environment.NewLine;
+			expected += "+--------------+-----------+----------------+";
+			tableString.ShouldBe(expected);
+		}
+
+		[Test]
+		public void BasicTableWithCenterColumnAlignmentShouldLookLikeThis()
+		{
+			// Arrange
+			var listOfTestClasses = DataProvider.ListOfTestData(1);
+			var tableObj = Table<TestDataType>.Create(listOfTestClasses);
+			tableObj.Columns[3].Hide = true; // hide date field 
+
+			// Act
+			tableObj.ColumnAlignment = Alignment.Center;
+			var tableString = tableObj.ToString();
+
+			// Assert
+			string expected = "";
+			expected += "+--------------+-----------+----------------+" + Environment.NewLine;
+			expected += "| StringColumn | IntColumn | CurrencyColumn |" + Environment.NewLine;
+			expected += "+--------------+-----------+----------------+" + Environment.NewLine;
+			expected += "|     AAAA     |    999    |      19.95     |" + Environment.NewLine;
+			expected += "+--------------+-----------+----------------+";
+			tableString.ShouldBe(expected);
+		}
+
+		[Test]
+		public void BasicTableWithRightHeaderAlignmentShouldLookLikeThis()
+		{
+			// Arrange
+			var listOfTestClasses = DataProvider.ListOfTestData(1);
+			listOfTestClasses[0].StringColumn = "Longer than header string";
+			var tableObj = Table<TestDataType>.Create(listOfTestClasses);
+			tableObj.Columns[3].Hide = true; // hide date field 
+
+			// Act
+			tableObj.HeaderAlignment = Alignment.Right;
+			var tableString = tableObj.ToString();
+
+			// Assert
+			string expected = "";
+			expected += "+---------------------------+-----------+----------------+" + Environment.NewLine;
+			expected += "|              StringColumn | IntColumn | CurrencyColumn |" + Environment.NewLine;
+			expected += "+---------------------------+-----------+----------------+" + Environment.NewLine;
+			expected += "| Longer than header string | 999       | 19.95          |" + Environment.NewLine;
+			expected += "+---------------------------+-----------+----------------+";
+			tableString.ShouldBe(expected);
+		}
+
+		[Test]
+		public void BasicTableWithCenterHeaderAlignmentShouldLookLikeThis()
+		{
+			// Arrange
+			var listOfTestClasses = DataProvider.ListOfTestData(1);
+			listOfTestClasses[0].StringColumn = "Longer than header string";
+			var tableObj = Table<TestDataType>.Create(listOfTestClasses);
+			tableObj.Columns[3].Hide = true; // hide date field 
+
+			// Act
+			tableObj.HeaderAlignment = Alignment.Center;
+			var tableString = tableObj.ToString();
+
+			// Assert
+			string expected = "";
+			expected += "+---------------------------+-----------+----------------+" + Environment.NewLine;
+			expected += "|        StringColumn       | IntColumn | CurrencyColumn |" + Environment.NewLine;
+			expected += "+---------------------------+-----------+----------------+" + Environment.NewLine;
+			expected += "| Longer than header string | 999       | 19.95          |" + Environment.NewLine;
+			expected += "+---------------------------+-----------+----------------+";
+			tableString.ShouldBe(expected);
+		}
+
+		[Test]
+		public void BasicTableWithCenterAlignmentAndLongStringBehaviourShouldLookLikeThis()
+		{
+			// Arrange
+			var listOfTestClasses = DataProvider.ListOfTestData(1);
+			listOfTestClasses[0].StringColumn = "Longer than header string";
+			var tableObj = Table<TestDataType>.Create(listOfTestClasses);
+			tableObj.Columns[3].Hide = true; // hide date field 
+
+			// Act
+			tableObj.HeaderAlignment = Alignment.Center;
+			var tableString = tableObj.ToString();
+
+			// Assert
+			string expected = "";
+			expected += "+---------------------------+-----------+----------------+" + Environment.NewLine;
+			expected += "|        StringColumn       | IntColumn | CurrencyColumn |" + Environment.NewLine;
+			expected += "+---------------------------+-----------+----------------+" + Environment.NewLine;
+			expected += "| Longer than header string | 999       | 19.95          |" + Environment.NewLine;
+			expected += "+---------------------------+-----------+----------------+";
+			tableString.ShouldBe(expected);
+		}
+	}
 
 }

--- a/ConTabs.Tests/ConformanceTests.cs
+++ b/ConTabs.Tests/ConformanceTests.cs
@@ -368,29 +368,5 @@ namespace ConTabs.Tests
 			expected += "+---------------------------+-----------+----------------+";
 			tableString.ShouldBe(expected);
 		}
-
-		[Test]
-		public void BasicTableWithCenterAlignmentAndLongStringBehaviourShouldLookLikeThis()
-		{
-			// Arrange
-			var listOfTestClasses = DataProvider.ListOfTestData(1);
-			listOfTestClasses[0].StringColumn = "Longer than header string";
-			var tableObj = Table<TestDataType>.Create(listOfTestClasses);
-			tableObj.Columns[3].Hide = true; // hide date field 
-
-			// Act
-			tableObj.HeaderAlignment = Alignment.Center;
-			var tableString = tableObj.ToString();
-
-			// Assert
-			string expected = "";
-			expected += "+---------------------------+-----------+----------------+" + Environment.NewLine;
-			expected += "|       StringColumn        | IntColumn | CurrencyColumn |" + Environment.NewLine;
-			expected += "+---------------------------+-----------+----------------+" + Environment.NewLine;
-			expected += "| Longer than header string | 999       | 19.95          |" + Environment.NewLine;
-			expected += "+---------------------------+-----------+----------------+";
-			tableString.ShouldBe(expected);
-		}
 	}
-
 }

--- a/ConTabs/Alignment.cs
+++ b/ConTabs/Alignment.cs
@@ -26,7 +26,7 @@ namespace ConTabs
 			var padLeft = (colMaxWidth - input.Length) / 2;
 			var padRight = (colMaxWidth - input.Length) % 2 == 0 ? padLeft : padLeft + 1;
 
-			return GetPaddingSpaces(padRight) + input + GetPaddingSpaces(padLeft);
+			return GetPaddingSpaces(padLeft) + input + GetPaddingSpaces(padRight);
 		}
 
 		private static string GetPaddingSpaces(int amount)

--- a/ConTabs/Alignment.cs
+++ b/ConTabs/Alignment.cs
@@ -1,0 +1,47 @@
+﻿using System;
+
+namespace ConTabs
+{
+	public class Alignment
+	{
+		public Func<string, int, string> Method { get; set; }
+		public static Alignment Default => Left;
+
+		public static Alignment Left = new Alignment { Method = AlignLeft };
+		public static Alignment Right = new Alignment { Method = AlignRight };
+		public static Alignment Center = new Alignment { Method = AlignCenter };
+
+		private static string AlignLeft(string input, int colMaxWidth)
+		{
+			return input + GetPaddingSpaces(colMaxWidth - input.Length);
+		}
+
+		private static string AlignRight(string input, int colMaxWidth)
+		{
+			return GetPaddingSpaces(colMaxWidth - input.Length) + input;
+		}
+
+		private static string AlignCenter(string input, int colMaxWidth)
+		{
+			var padLeft = (colMaxWidth - input.Length) / 2;
+			var padRight = (colMaxWidth - input.Length) % 2 == 0 ? padLeft : padLeft + 1;
+
+			return GetPaddingSpaces(padRight) + input + GetPaddingSpaces(padLeft);
+		}
+
+		private static string GetPaddingSpaces(int amount)
+		{
+			return new string(' ', amount);
+		}
+
+		public string ProcessString(string input, int colMaxWidth)
+		{
+			if (input == string.Empty)
+			{
+				GetPaddingSpaces(colMaxWidth);
+			}
+
+			return Method(input, colMaxWidth);
+		}
+	}
+}

--- a/ConTabs/Alignment.cs
+++ b/ConTabs/Alignment.cs
@@ -2,46 +2,46 @@
 
 namespace ConTabs
 {
-	public class Alignment
-	{
-		public Func<string, int, string> Method { get; set; }
-		public static Alignment Default => Left;
+    public class Alignment
+    {
+        public Func<string, int, string> Method { get; set; }
+        public static Alignment Default => Left;
 
-		public static Alignment Left = new Alignment { Method = AlignLeft };
-		public static Alignment Right = new Alignment { Method = AlignRight };
-		public static Alignment Center = new Alignment { Method = AlignCenter };
+        public static Alignment Left = new Alignment { Method = AlignLeft };
+        public static Alignment Right = new Alignment { Method = AlignRight };
+        public static Alignment Center = new Alignment { Method = AlignCenter };
 
-		private static string AlignLeft(string input, int colMaxWidth)
-		{
-			return input + GetPaddingSpaces(colMaxWidth - input.Length);
-		}
+        private static string AlignLeft(string input, int colMaxWidth)
+        {
+            return input + GetPaddingSpaces(colMaxWidth - input.Length);
+        }
 
-		private static string AlignRight(string input, int colMaxWidth)
-		{
-			return GetPaddingSpaces(colMaxWidth - input.Length) + input;
-		}
+        private static string AlignRight(string input, int colMaxWidth)
+        {
+            return GetPaddingSpaces(colMaxWidth - input.Length) + input;
+        }
 
-		private static string AlignCenter(string input, int colMaxWidth)
-		{
-			var padLeft = (colMaxWidth - input.Length) / 2;
-			var padRight = (colMaxWidth - input.Length) % 2 == 0 ? padLeft : padLeft + 1;
+        private static string AlignCenter(string input, int colMaxWidth)
+        {
+            var padLeft = (colMaxWidth - input.Length) / 2;
+            var padRight = (colMaxWidth - input.Length) % 2 == 0 ? padLeft : padLeft + 1;
 
-			return GetPaddingSpaces(padLeft) + input + GetPaddingSpaces(padRight);
-		}
+            return GetPaddingSpaces(padLeft) + input + GetPaddingSpaces(padRight);
+        }
 
-		private static string GetPaddingSpaces(int amount)
-		{
-			return new string(' ', amount);
-		}
+        private static string GetPaddingSpaces(int amount)
+        {
+            return new string(' ', amount);
+        }
 
-		public string ProcessString(string input, int colMaxWidth)
-		{
-			if (input == string.Empty)
-			{
-				GetPaddingSpaces(colMaxWidth);
-			}
+        public string ProcessString(string input, int colMaxWidth)
+        {
+            if (input == string.Empty)
+            {
+                GetPaddingSpaces(colMaxWidth);
+            }
 
-			return Method(input, colMaxWidth);
-		}
-	}
+            return Method(input, colMaxWidth);
+        }
+    }
 }

--- a/ConTabs/Column.cs
+++ b/ConTabs/Column.cs
@@ -15,7 +15,7 @@ namespace ConTabs
         public string FormatString { get; set; }
         public bool Hide { get; set; }
         public LongStringBehaviour LongStringBehaviour { get; set; }
-		public Alignment Alignment { get; set; }
+        public Alignment Alignment { get; set; }
 
         public List<Object> Values { get; set; }
         public int MaxWidth
@@ -37,8 +37,8 @@ namespace ConTabs
         public Column(Type type, string name)
         {
             LongStringBehaviour = LongStringBehaviour.Default;
-			Alignment			= Alignment.Default;
-			SourceType			= type;
+            Alignment			= Alignment.Default;
+            SourceType			= type;
             PropertyName        = name;
             ColumnName          = name;
         }

--- a/ConTabs/Column.cs
+++ b/ConTabs/Column.cs
@@ -37,8 +37,8 @@ namespace ConTabs
         public Column(Type type, string name)
         {
             LongStringBehaviour = LongStringBehaviour.Default;
-            Alignment			= Alignment.Default;
-            SourceType			= type;
+            Alignment           = Alignment.Default;
+            SourceType          = type;
             PropertyName        = name;
             ColumnName          = name;
         }

--- a/ConTabs/Column.cs
+++ b/ConTabs/Column.cs
@@ -38,7 +38,7 @@ namespace ConTabs
         {
             LongStringBehaviour = LongStringBehaviour.Default;
 			Alignment			= Alignment.Default;
-			SourceType          = type;
+			SourceType			= type;
             PropertyName        = name;
             ColumnName          = name;
         }

--- a/ConTabs/Column.cs
+++ b/ConTabs/Column.cs
@@ -15,6 +15,7 @@ namespace ConTabs
         public string FormatString { get; set; }
         public bool Hide { get; set; }
         public LongStringBehaviour LongStringBehaviour { get; set; }
+		public Alignment Alignment { get; set; }
 
         public List<Object> Values { get; set; }
         public int MaxWidth
@@ -36,7 +37,8 @@ namespace ConTabs
         public Column(Type type, string name)
         {
             LongStringBehaviour = LongStringBehaviour.Default;
-            SourceType          = type;
+			Alignment			= Alignment.Default;
+			SourceType          = type;
             PropertyName        = name;
             ColumnName          = name;
         }

--- a/ConTabs/OutputBuilder.cs
+++ b/ConTabs/OutputBuilder.cs
@@ -72,15 +72,15 @@ namespace ConTabs
                 sb.Append(style.Wall);
                 foreach (var col in table._colsShown)
                 {
-                    sb.Append(" " + col.ColumnName + new string(' ', col.MaxWidth - col.ColumnName.Length) + " " + style.Wall);
+                    sb.Append(" " + table.HeaderAlignment.ProcessString(col.ColumnName, col.MaxWidth) + " " + style.Wall);
                 }
             }
 
             private void DataRow(int i)
             {
-                var cols = table._colsShown.Select(c => new CellParts(c.StringValForCol(c.Values[i]), c.MaxWidth)).ToList();
+				var cols = table._colsShown.Select(c => new CellParts(c.StringValForCol(c.Values[i]), c.MaxWidth, c.Alignment)).ToList();
 
-                var maxLines = cols.Max(c => c.LineCount);
+				var maxLines = cols.Max(c => c.LineCount);
 
                 for (int j = 0; j < maxLines; j++)
                 {
@@ -94,7 +94,7 @@ namespace ConTabs
                 foreach (var part in parts)
                 {
                     string val = part.GetLine(line);
-                    sb.Append(" " + val + new string(' ', part.ColMaxWidth - val.Length) + " " + style.Wall);
+                    sb.Append(" " + part.Alignment.ProcessString(val, part.ColMaxWidth) + " " + style.Wall);
                 }
             }
 
@@ -114,14 +114,16 @@ namespace ConTabs
 
             private class CellParts
             {
-                public CellParts(string value, int width)
+                public CellParts(string value, int width, Alignment alignment)
                 {
                     _value = value;
                     ColMaxWidth = width;
-                }
+					Alignment = alignment;
+				}
 
                 public int ColMaxWidth { get; set; }
-                public int LineCount => _lines.Length;
+				public Alignment Alignment { get; set; }
+				public int LineCount => _lines.Length;
                 public string GetLine(int i)
                 {
                     if (_lines.Length > i) return _lines[i];

--- a/ConTabs/OutputBuilder.cs
+++ b/ConTabs/OutputBuilder.cs
@@ -78,9 +78,9 @@ namespace ConTabs
 
             private void DataRow(int i)
             {
-				var cols = table._colsShown.Select(c => new CellParts(c.StringValForCol(c.Values[i]), c.MaxWidth, c.Alignment)).ToList();
+                var cols = table._colsShown.Select(c => new CellParts(c.StringValForCol(c.Values[i]), c.MaxWidth, c.Alignment)).ToList();
 
-				var maxLines = cols.Max(c => c.LineCount);
+                var maxLines = cols.Max(c => c.LineCount);
 
                 for (int j = 0; j < maxLines; j++)
                 {
@@ -118,12 +118,12 @@ namespace ConTabs
                 {
                     _value = value;
                     ColMaxWidth = width;
-					Alignment = alignment;
-				}
+                    Alignment = alignment;
+                }
 
         internal int ColMaxWidth { get; set; }
-				internal Alignment Alignment { get; set; }
-				internal int LineCount => _lines.Length;
+                internal Alignment Alignment { get; set; }
+                internal int LineCount => _lines.Length;
                 public string GetLine(int i)
                 {
                     if (_lines.Length > i) return _lines[i];

--- a/ConTabs/Table.cs
+++ b/ConTabs/Table.cs
@@ -7,30 +7,30 @@ using System.Diagnostics;
 
 namespace ConTabs
 {
-	[DebuggerDisplay("Table with {Columns.Count} available columns")]
-	public sealed partial class Table<T> where T : class
-	{
-		public Columns Columns { get; set; }
-		public Alignment HeaderAlignment { get; set; }
+    [DebuggerDisplay("Table with {Columns.Count} available columns")]
+    public sealed partial class Table<T> where T : class
+    {
+        public Columns Columns { get; set; }
+        public Alignment HeaderAlignment { get; set; }
 
-		private Alignment _columnAlignment { get; set; }
-		public Alignment ColumnAlignment
-		{
-			get
-			{
-				return _columnAlignment;
-			}
-			set
-			{
-				_columnAlignment = value;
-				if (Columns != null)
-				{
-					Columns.ForEach(c => c.Alignment = _columnAlignment);
-				}
-			}
-		}
+        private Alignment _columnAlignment { get; set; }
+        public Alignment ColumnAlignment
+        {
+            get
+            {
+                return _columnAlignment;
+            }
+            set
+            {
+                _columnAlignment = value;
+                if (Columns != null)
+                {
+                    Columns.ForEach(c => c.Alignment = _columnAlignment);
+                }
+            }
+        }
 
-		internal List<Column> _colsShown => Columns.Where(c => !c.Hide).ToList();
+        internal List<Column> _colsShown => Columns.Where(c => !c.Hide).ToList();
         public Style TableStyle { get; set; }
 
         private IEnumerable<T> _data;
@@ -71,10 +71,10 @@ namespace ConTabs
         private Table()
         {
             TableStyle = Style.Default;
-			HeaderAlignment = Alignment.Default;
-			ColumnAlignment = Alignment.Default;
+            HeaderAlignment = Alignment.Default;
+            ColumnAlignment = Alignment.Default;
 
-			var props = GetDeclaredAndInheritedProperties(typeof(T).GetTypeInfo());
+            var props = GetDeclaredAndInheritedProperties(typeof(T).GetTypeInfo());
             var cols = props
                 .Where(p => p.GetMethod.IsPublic)
                 .Select(p => new Column(p.PropertyType, p.Name))

--- a/ConTabs/Table.cs
+++ b/ConTabs/Table.cs
@@ -7,11 +7,30 @@ using System.Diagnostics;
 
 namespace ConTabs
 {
-    [DebuggerDisplay("Table with {Columns.Count} available columns")]
-    public partial class Table<T> where T:class
-    {
-        public Columns Columns { get; set; }
-        internal List<Column> _colsShown => Columns.Where(c => !c.Hide).ToList();
+	[DebuggerDisplay("Table with {Columns.Count} available columns")]
+	public partial class Table<T> where T : class
+	{
+		public Columns Columns { get; set; }
+		public Alignment HeaderAlignment { get; set; }
+
+		private Alignment _columnAlignment { get; set; }
+		public Alignment ColumnAlignment
+		{
+			get
+			{
+				return _columnAlignment;
+			}
+			set
+			{
+				_columnAlignment = value;
+				if (Columns != null)
+				{
+					Columns.ForEach(c => c.Alignment = _columnAlignment);
+				}
+			}
+		}
+
+		internal List<Column> _colsShown => Columns.Where(c => !c.Hide).ToList();
         public Style TableStyle { get; set; }
 
         private IEnumerable<T> _data;
@@ -52,7 +71,10 @@ namespace ConTabs
         private Table()
         {
             TableStyle = Style.Default;
-            var props = GetDeclaredAndInheritedProperties(typeof(T).GetTypeInfo());
+			HeaderAlignment = Alignment.Default;
+			ColumnAlignment = Alignment.Default;
+
+			var props = GetDeclaredAndInheritedProperties(typeof(T).GetTypeInfo());
             var cols = props
                 .Where(p => p.GetMethod.IsPublic)
                 .Select(p => new Column(p.PropertyType, p.Name))


### PR DESCRIPTION
Added options for alignment! The options are left (which is default), right and center. 

You can set a HeaderAlignment property to align the headers of your table.
You can set the ColumnAlignment property of a table to assign an alignment to every column in your table, or you can change the Alignment property on an individual column to overwrite that setting. 

Let me know what you think!

(Also: this is my first PR ever so any feedback or tips are more than welcome!) 