### PR TITLE
Added a Padding property to Table.

### DIFF
--- a/ConTabs.Tests/ConformanceTests.cs
+++ b/ConTabs.Tests/ConformanceTests.cs
@@ -29,6 +29,27 @@ namespace ConTabs.Tests
         }
 
         [Test]
+        public void BasicTableWithNoDataAndExplicitPaddingShouldLookLikeThis()
+        {
+            // Arrange
+            var listOfTestClasses = DataProvider.ListOfTestData(0);
+            var tableObj = Table<TestDataType>.Create(listOfTestClasses);
+            tableObj.Padding = 0;
+
+            // Act
+            var tableString = tableObj.ToString();
+
+            // Assert
+            string expected = "";
+            expected += "+------------+---------+--------------+--------------+" + Environment.NewLine;
+            expected += "|StringColumn|IntColumn|CurrencyColumn|DateTimeColumn|" + Environment.NewLine;
+            expected += "+------------+---------+--------------+--------------+" + Environment.NewLine;
+            expected += "|                      no data                       |" + Environment.NewLine;
+            expected += "+------------+---------+--------------+--------------+";
+            tableString.ShouldBe(expected);
+        }
+
+        [Test]
         public void BasicTableWithOneLineOfDataShouldLookLikeThis()
         {
             // Arrange
@@ -46,6 +67,28 @@ namespace ConTabs.Tests
             expected += "+--------------+-----------+----------------+" + Environment.NewLine;
             expected += "| AAAA         | 999       | 19.95          |" + Environment.NewLine;
             expected += "+--------------+-----------+----------------+";
+            tableString.ShouldBe(expected);
+        }
+
+        [Test]
+        public void BasicTableWithOneLineOfDataAndExplicitPaddingShouldLookLikeThis()
+        {
+            // Arrange
+            var listOfTestClasses = DataProvider.ListOfTestData(1);
+            var tableObj = Table<TestDataType>.Create(listOfTestClasses);
+            tableObj.Columns[3].Hide = true; // hide date field 
+            tableObj.Padding = 3;
+
+            // Act
+            var tableString = tableObj.ToString();
+
+            // Assert
+            string expected = "";
+            expected += "+------------------+---------------+--------------------+" + Environment.NewLine;
+            expected += "|   StringColumn   |   IntColumn   |   CurrencyColumn   |" + Environment.NewLine;
+            expected += "+------------------+---------------+--------------------+" + Environment.NewLine;
+            expected += "|   AAAA           |   999         |   19.95            |" + Environment.NewLine;
+            expected += "+------------------+---------------+--------------------+";
             tableString.ShouldBe(expected);
         }
 
@@ -72,6 +115,29 @@ namespace ConTabs.Tests
         }
 
         [Test]
+        public void BasicTableWithOneLineOfDataAndEmptyStringValueWithExplicitPaddingShouldLookLikeThis()
+        {
+            // Arrange
+            var listOfTestClasses = DataProvider.ListOfTestData(1);
+            listOfTestClasses[0].StringColumn = string.Empty;
+            var tableObj = Table<TestDataType>.Create(listOfTestClasses);
+            tableObj.Columns[3].Hide = true; // hide date field 
+            tableObj.Padding = 4;
+
+            // Act
+            var tableString = tableObj.ToString();
+
+            // Assert
+            string expected = "";
+            expected += "+--------------------+-----------------+----------------------+" + Environment.NewLine;
+            expected += "|    StringColumn    |    IntColumn    |    CurrencyColumn    |" + Environment.NewLine;
+            expected += "+--------------------+-----------------+----------------------+" + Environment.NewLine;
+            expected += "|                    |    999          |    19.95             |" + Environment.NewLine;
+            expected += "+--------------------+-----------------+----------------------+";
+            tableString.ShouldBe(expected);
+        }
+
+        [Test]
         public void TableStyledAsUnicodePipesShouldLookLikeThis()
         {
             // Arrange
@@ -89,6 +155,28 @@ namespace ConTabs.Tests
             expected += "╠══════╬══════╣" + Environment.NewLine;
             expected += "║ 1    ║ 3    ║" + Environment.NewLine;
             expected += "╚══════╩══════╝";
+            tableString.ShouldBe(expected);
+        }
+
+        [Test]
+        public void TableStyledAsUnicodePipesWithExplicitPaddingShouldLookLikeThis()
+        {
+            // Arrange
+            var listOfTestClasses = DataProvider.ListOfMinimalData(1);
+            var tableObj = Table<MinimalDataType>.Create(listOfTestClasses);
+            tableObj.TableStyle = Style.UnicodePipes;
+            tableObj.Padding = 0;
+
+            // Act
+            var tableString = tableObj.ToString();
+
+            // Assert
+            string expected = "";
+            expected += "╔════╦════╗" + Environment.NewLine;
+            expected += "║IntA║IntB║" + Environment.NewLine;
+            expected += "╠════╬════╣" + Environment.NewLine;
+            expected += "║1   ║3   ║" + Environment.NewLine;
+            expected += "╚════╩════╝";
             tableString.ShouldBe(expected);
         }
 
@@ -177,6 +265,28 @@ namespace ConTabs.Tests
         }
 
         [Test]
+        public void TableStyledAsUnicodeArcsWithExplicitPaddingShouldLookLikeThis()
+        {
+            // Arrange
+            var listOfTestClasses = DataProvider.ListOfMinimalData(1);
+            var tableObj = Table<MinimalDataType>.Create(listOfTestClasses);
+            tableObj.TableStyle = Style.UnicodeArcs;
+            tableObj.Padding = 2;
+
+            // Act
+            var tableString = tableObj.ToString();
+
+            // Assert
+            string expected = "";
+            expected += "╭────────┬────────╮" + Environment.NewLine;
+            expected += "│  IntA  │  IntB  │" + Environment.NewLine;
+            expected += "├────────┼────────┤" + Environment.NewLine;
+            expected += "│  1     │  3     │" + Environment.NewLine;
+            expected += "╰────────┴────────╯";
+            tableString.ShouldBe(expected);
+        }
+
+        [Test]
         public void TableStyledAsDotsShouldLookLikeThis()
         {
             // Arrange
@@ -224,6 +334,33 @@ namespace ConTabs.Tests
         }
 
         [Test]
+        public void BasicTableWithWrappedStringWithExplicitPaddingShouldLookLikeThis()
+        {
+            // Arrange
+            var listOfTestClasses = DataProvider.ListOfTestData(1);
+            listOfTestClasses[0].StringColumn = "This string will need to be wrapped";
+            var tableObj = Table<TestDataType>.Create(listOfTestClasses);
+            tableObj.Columns[3].Hide = true; // hide date field 
+            tableObj.Padding = 2;
+
+            // Act
+            tableObj.Columns[0].LongStringBehaviour = LongStringBehaviour.Wrap;
+            tableObj.Columns[0].LongStringBehaviour.Width = 12;
+            var tableString = tableObj.ToString();
+
+            // Assert
+            string expected = "";
+            expected += "+----------------+-------------+------------------+" + Environment.NewLine;
+            expected += "|  StringColumn  |  IntColumn  |  CurrencyColumn  |" + Environment.NewLine;
+            expected += "+----------------+-------------+------------------+" + Environment.NewLine;
+            expected += "|  This string   |  999        |  19.95           |" + Environment.NewLine;
+            expected += "|  will need to  |             |                  |" + Environment.NewLine;
+            expected += "|  be wrapped    |             |                  |" + Environment.NewLine;
+            expected += "+----------------+-------------+------------------+";
+            tableString.ShouldBe(expected);
+        }
+
+        [Test]
         public void BasicTableWithWrappedStringAndRightAlignmentShouldLookLikeThis()
         {
             // Arrange
@@ -247,6 +384,34 @@ namespace ConTabs.Tests
             expected += "| will need to |           |                |" + Environment.NewLine;
             expected += "|   be wrapped |           |                |" + Environment.NewLine;
             expected += "+--------------+-----------+----------------+";
+            tableString.ShouldBe(expected);
+        }
+
+        [Test]
+        public void BasicTableWithWrappedStringAndRightAlignmentWithExplicitPaddingShouldLookLikeThis()
+        {
+            // Arrange
+            var listOfTestClasses = DataProvider.ListOfTestData(1);
+            listOfTestClasses[0].StringColumn = "This string will need to be wrapped";
+            var tableObj = Table<TestDataType>.Create(listOfTestClasses);
+            tableObj.Columns[3].Hide = true; // hide date field 
+            tableObj.Padding = 0;
+
+            // Act
+            tableObj.Columns[0].LongStringBehaviour = LongStringBehaviour.Wrap;
+            tableObj.Columns[0].LongStringBehaviour.Width = 12;
+            tableObj.Columns[0].Alignment = Alignment.Right;
+            var tableString = tableObj.ToString();
+
+            // Assert
+            string expected = "";
+            expected += "+------------+---------+--------------+" + Environment.NewLine;
+            expected += "|StringColumn|IntColumn|CurrencyColumn|" + Environment.NewLine;
+            expected += "+------------+---------+--------------+" + Environment.NewLine;
+            expected += "| This string|999      |19.95         |" + Environment.NewLine;
+            expected += "|will need to|         |              |" + Environment.NewLine;
+            expected += "|  be wrapped|         |              |" + Environment.NewLine;
+            expected += "+------------+---------+--------------+";
             tableString.ShouldBe(expected);
         }
 
@@ -278,6 +443,34 @@ namespace ConTabs.Tests
         }
 
         [Test]
+        public void BasicTableWithWrappedStringAndCenterAlignmentWithExplicitPaddingShouldLookLikeThis()
+        {
+            // Arrange
+            var listOfTestClasses = DataProvider.ListOfTestData(1);
+            listOfTestClasses[0].StringColumn = "This string will need to be wrapped";
+            var tableObj = Table<TestDataType>.Create(listOfTestClasses);
+            tableObj.Columns[3].Hide = true; // hide date field 
+            tableObj.Padding = 2;
+
+            // Act
+            tableObj.Columns[0].LongStringBehaviour = LongStringBehaviour.Wrap;
+            tableObj.Columns[0].LongStringBehaviour.Width = 12;
+            tableObj.Columns[0].Alignment = Alignment.Center;
+            var tableString = tableObj.ToString();
+
+            // Assert
+            string expected = "";
+            expected += "+----------------+-------------+------------------+" + Environment.NewLine;
+            expected += "|  StringColumn  |  IntColumn  |  CurrencyColumn  |" + Environment.NewLine;
+            expected += "+----------------+-------------+------------------+" + Environment.NewLine;
+            expected += "|  This string   |  999        |  19.95           |" + Environment.NewLine;
+            expected += "|  will need to  |             |                  |" + Environment.NewLine;
+            expected += "|   be wrapped   |             |                  |" + Environment.NewLine;
+            expected += "+----------------+-------------+------------------+";
+            tableString.ShouldBe(expected);
+        }
+
+        [Test]
         public void BasicTableWithTruncatedStringShouldLookLikeThis()
         {
             // Arrange
@@ -297,6 +490,30 @@ namespace ConTabs.Tests
             expected += "+-----------------+-----------+----------------+" + Environment.NewLine;
             expected += "| This string ... | 999       | 19.95          |" + Environment.NewLine;
             expected += "+-----------------+-----------+----------------+";
+            tableString.ShouldBe(expected);
+        }
+
+        [Test]
+        public void BasicTableWithTruncatedStringWithExplicitPaddingShouldLookLikeThis()
+        {
+            // Arrange
+            var listOfTestClasses = DataProvider.ListOfTestData(1);
+            listOfTestClasses[0].StringColumn = "This string will need to be wrapped";
+            var tableObj = Table<TestDataType>.Create(listOfTestClasses);
+            tableObj.Columns[3].Hide = true; // hide date field 
+            tableObj.Padding = 3;
+
+            // Act
+            tableObj.Columns[0].LongStringBehaviour = LongStringBehaviour.TruncateWithEllipsis;
+            var tableString = tableObj.ToString();
+
+            // Assert
+            string expected = "";
+            expected += "+---------------------+---------------+--------------------+" + Environment.NewLine;
+            expected += "|   StringColumn      |   IntColumn   |   CurrencyColumn   |" + Environment.NewLine;
+            expected += "+---------------------+---------------+--------------------+" + Environment.NewLine;
+            expected += "|   This string ...   |   999         |   19.95            |" + Environment.NewLine;
+            expected += "+---------------------+---------------+--------------------+";
             tableString.ShouldBe(expected);
         }
 
@@ -364,6 +581,30 @@ namespace ConTabs.Tests
             expected += "+---------------------------+-----------+----------------+" + Environment.NewLine;
             expected += "| Longer than header string | 999       | 19.95          |" + Environment.NewLine;
             expected += "+---------------------------+-----------+----------------+";
+            tableString.ShouldBe(expected);
+        }
+
+        [Test]
+        public void BasicTableWithRightHeaderAlignmentWithExplicitPaddingShouldLookLikeThis()
+        {
+            // Arrange
+            var listOfTestClasses = DataProvider.ListOfTestData(1);
+            listOfTestClasses[0].StringColumn = "Longer than header string";
+            var tableObj = Table<TestDataType>.Create(listOfTestClasses);
+            tableObj.Columns[3].Hide = true; // hide date field 
+            tableObj.Padding = 0;
+
+            // Act
+            tableObj.HeaderAlignment = Alignment.Right;
+            var tableString = tableObj.ToString();
+
+            // Assert
+            string expected = "";
+            expected += "+-------------------------+---------+--------------+" + Environment.NewLine;
+            expected += "|             StringColumn|IntColumn|CurrencyColumn|" + Environment.NewLine;
+            expected += "+-------------------------+---------+--------------+" + Environment.NewLine;
+            expected += "|Longer than header string|999      |19.95         |" + Environment.NewLine;
+            expected += "+-------------------------+---------+--------------+";
             tableString.ShouldBe(expected);
         }
 

--- a/ConTabs.Tests/FormatTests.cs
+++ b/ConTabs.Tests/FormatTests.cs
@@ -75,6 +75,32 @@ namespace ConTabs.Tests
         }
 
         [Test]
+        public void DateTimeFieldCanBeFormattedInTableWithExplicitPadding()
+        {
+            // Arrange
+            var listOfTestClasses = DataProvider.ListOfTestData(1);
+            var tableObj = Table<TestDataType>.Create(listOfTestClasses);
+            tableObj.Padding = 2;
+
+            tableObj.Columns[0].Hide = true; // only show date field
+            tableObj.Columns[1].Hide = true;
+            tableObj.Columns[2].Hide = true;
+
+            // Act
+            tableObj.Columns[3].FormatString = "yy-MM-dd";
+            var tableString = tableObj.ToString();
+
+            // Assert
+            string expected = "";
+            expected += "+------------------+" + Environment.NewLine;
+            expected += "|  DateTimeColumn  |" + Environment.NewLine;
+            expected += "+------------------+" + Environment.NewLine;
+            expected += "|  17-01-01        |" + Environment.NewLine;
+            expected += "+------------------+";
+            tableString.ShouldBe(expected);
+        }
+
+        [Test]
         public void CurrencyFieldCanBeFormattedInTable()
         {
             // Arrange
@@ -97,6 +123,33 @@ namespace ConTabs.Tests
             expected += "| £19.95         |" + Environment.NewLine;
             expected += "| -£2000.00      |" + Environment.NewLine;
             expected += "+----------------+";
+            tableString.ShouldBe(expected);
+        }
+
+        [Test]
+        public void CurrencyFieldCanBeFormattedInTableWithExplicitPadding()
+        {
+            // Arrange
+            var listOfTestClasses = DataProvider.ListOfTestData(2);
+            var tableObj = Table<TestDataType>.Create(listOfTestClasses);
+            tableObj.Padding = 0;
+
+            tableObj.Columns[0].Hide = true; // only show currency field
+            tableObj.Columns[1].Hide = true;
+            tableObj.Columns[3].Hide = true;
+
+            // Act
+            tableObj.Columns[2].FormatString = "£0.00";
+            var tableString = tableObj.ToString();
+
+            // Assert
+            string expected = "";
+            expected += "+--------------+" + Environment.NewLine;
+            expected += "|CurrencyColumn|" + Environment.NewLine;
+            expected += "+--------------+" + Environment.NewLine;
+            expected += "|£19.95        |" + Environment.NewLine;
+            expected += "|-£2000.00     |" + Environment.NewLine;
+            expected += "+--------------+";
             tableString.ShouldBe(expected);
         }
 

--- a/ConTabs/OutputBuilder.cs
+++ b/ConTabs/OutputBuilder.cs
@@ -51,7 +51,7 @@ namespace ConTabs
                 sb.Append(GetCorner(v, LeftCentreRight.Left));
                 for (int i = 0; i < table._colsShown.Count; i++)
                 {
-                    sb.Append(new string(style.Floor, table._colsShown[i].MaxWidth + 2));
+                    sb.Append(new string(style.Floor, table._colsShown[i].MaxWidth + (2 * table.Padding)));
                     if (i < table._colsShown.Count - 1) sb.Append(GetCorner(v, LeftCentreRight.Centre));
                 }
                 sb.Append(GetCorner(v, LeftCentreRight.Right));
@@ -72,7 +72,7 @@ namespace ConTabs
                 sb.Append(style.Wall);
                 foreach (var col in table._colsShown)
                 {
-                    sb.Append(" " + table.HeaderAlignment.ProcessString(col.ColumnName, col.MaxWidth) + " " + style.Wall);
+                    sb.Append(GetPaddingString(table.Padding) + table.HeaderAlignment.ProcessString(col.ColumnName, col.MaxWidth) + GetPaddingString(table.Padding) + style.Wall);
                 }
             }
 
@@ -94,7 +94,7 @@ namespace ConTabs
                 foreach (var part in parts)
                 {
                     string val = part.GetLine(line);
-                    sb.Append(" " + part.Alignment.ProcessString(val, part.ColMaxWidth) + " " + style.Wall);
+                    sb.Append(GetPaddingString(table.Padding) + part.Alignment.ProcessString(val, part.ColMaxWidth) + GetPaddingString(table.Padding) + style.Wall);
                 }
             }
 
@@ -138,6 +138,11 @@ namespace ConTabs
             private char GetCorner(TopMidBot v, LeftCentreRight h)
             {
                 return style.Corners[(int)h, (int)v];
+            }
+
+            private string GetPaddingString(int length)
+            {
+                return new String(' ', length);
             }
         }
     }

--- a/ConTabs/OutputBuilder.cs
+++ b/ConTabs/OutputBuilder.cs
@@ -61,7 +61,7 @@ namespace ConTabs
             {
                 var noDataText = "no data";
                 int colWidths = table._colsShown.Sum(c => c.MaxWidth);
-                int innerWidth = colWidths + (3 * table._colsShown.Count) - 1;
+                int innerWidth = colWidths + (2 * table._colsShown.Count * table.Padding) + (table._colsShown.Count + 1) - 2;
                 int leftPad = (innerWidth - noDataText.Length) / 2;
                 int rightPad = innerWidth - (leftPad + noDataText.Length);
                 sb.Append(style.Wall + new String(' ', leftPad) + noDataText + new string(' ', rightPad) + style.Wall);

--- a/ConTabs/Table.cs
+++ b/ConTabs/Table.cs
@@ -10,6 +10,7 @@ namespace ConTabs
     [DebuggerDisplay("Table with {Columns.Count} available columns")]
     public sealed partial class Table<T> where T : class
     {
+        public byte Padding { get; set; }
         public Columns Columns { get; set; }
         public Alignment HeaderAlignment { get; set; }
 
@@ -70,6 +71,7 @@ namespace ConTabs
 
         private Table()
         {
+            Padding = 1;
             TableStyle = Style.Default;
             HeaderAlignment = Alignment.Default;
             ColumnAlignment = Alignment.Default;

--- a/ConTabsDemo-DotNetFramework/Program.cs
+++ b/ConTabsDemo-DotNetFramework/Program.cs
@@ -13,6 +13,9 @@ namespace ConTabsDemo_DotNetFramework
             var Data = DemoDataProvider.ListOfDemoData();
 
             var table = Table<DemoDataType>.Create(Data);
+            table.Padding = 3;
+            table.HeaderAlignment = Alignment.Center;
+            table.ColumnAlignment = Alignment.Right;
             Console.WriteLine(table.ToString());
 
             Console.WriteLine("Press return to exit...");


### PR DESCRIPTION
Targeting issue #34.

Usage:
`var table = Table<Planet>.Create(Planets);
table.Padding = 0; // Default Padding is 1
Console.WriteLine(table.ToString());`

