### PR TITLE
Handle null column values by returning empty string (fix for #40)

### DIFF
--- a/ConTabs.Tests/ColumnTests.cs
+++ b/ConTabs.Tests/ColumnTests.cs
@@ -1,0 +1,80 @@
+﻿using NUnit.Framework;
+using Shouldly;
+using System.Collections.Generic;
+
+namespace ConTabs.Tests
+{
+    [TestFixture]
+    public class ColumnTests
+    {
+        [Test]
+        public void StringValForColWithNullDataShouldReturnEmptyString()
+        {
+            //Arrange
+            var column = new Column(typeof(string), "StringColumn");
+
+            //Act
+            var result = column.StringValForCol(null);
+
+            //Assert
+            result.ShouldBe("");
+        }
+
+        [Test]
+        public void MaxWidthWithNullValuesReturnsColumnNameLength()
+        {
+            //Arrange
+            var column = new Column(typeof(string), "StringColumn");
+
+            //Act
+            var result = column.MaxWidth;
+
+            //Assert
+            result.ShouldBe(12);
+        }
+
+        [Test]
+        public void MaxWidthWithZeroValuesReturnsColumnNameLength()
+        {
+            //Arrange
+            var column = new Column(typeof(string), "StringColumn");
+            column.Values = new List<object>();
+
+            //Act
+            var result = column.MaxWidth;
+
+            //Assert
+            result.ShouldBe(12);
+        }
+
+        [Test]
+        public void MaxWidthWithLongStringBehaviourReturnsLongStringBehaviourWidth()
+        {
+            //Arrange
+            var column = new Column(typeof(string), "StringColumn");
+            column.Values = new List<object>() { null };
+            column.LongStringBehaviour = LongStringBehaviour.Wrap;
+            column.LongStringBehaviour.Width = 15;
+
+            //Act
+            var result = column.MaxWidth;
+
+            //Assert
+            result.ShouldBe(15);
+        }
+
+        [Test]
+        public void MaxWidthWithValuesReturnsLengthOfLongestValue()
+        {
+            //Arrange
+            var column = new Column(typeof(string), "data");
+            column.Values = new List<object>() { "one", "two", "three", "four" };
+
+            //Act
+            var result = column.MaxWidth;
+
+            //Assert
+            result.ShouldBe(5);
+        }
+    }
+}

--- a/ConTabs.Tests/ConTabs.Tests.csproj
+++ b/ConTabs.Tests/ConTabs.Tests.csproj
@@ -56,6 +56,7 @@
     <Compile Include="Table-Basic.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="LongStringBehaviourTests.cs" />
+    <Compile Include="ColumnTests.cs" />
     <Compile Include="UsageTests.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/ConTabs/Column.cs
+++ b/ConTabs/Column.cs
@@ -61,7 +61,7 @@ namespace ConTabs
 
                 if (ToStringMethod == null)
                 {
-                    return casted.ToString();
+                    return (casted ?? string.Empty).ToString();
                 }
                 else
                 {


### PR DESCRIPTION
The Column class StringValForCol method checks for Null values and returns an empty string rather than a NullReferenceException message.
A new unit test class ColumnTests has been added to test the StringValForCol method and MaxWidth property getter.