### PR TITLE
Computed columns

### DIFF
--- a/ConTabs.Tests/ConTabs.Tests.csproj
+++ b/ConTabs.Tests/ConTabs.Tests.csproj
@@ -52,6 +52,7 @@
     <Compile Include="ConformanceTests.cs" />
     <Compile Include="FormatTests.cs" />
     <Compile Include="AlignmentTests.cs" />
+    <Compile Include="GeneratedColumnTests.cs" />
     <Compile Include="OrderingTests.cs" />
     <Compile Include="Table-AnonymousTypes.cs" />
     <Compile Include="Table-Basic.cs" />

--- a/ConTabs.Tests/GeneratedColumnTests.cs
+++ b/ConTabs.Tests/GeneratedColumnTests.cs
@@ -1,0 +1,73 @@
+﻿using NUnit.Framework;
+using Shouldly;
+using ConTabs.TestData;
+using System;
+
+namespace ConTabs.Tests
+{
+	[TestFixture]
+	public class GeneratedColumnTests
+	{
+		[Test]
+		public void ColumnGeneratedUsingInlineFunction()
+		{
+			// Arrange
+			var data = DemoDataProvider.ListOfDemoData();
+			var table = Table<Planet>.Create(data);
+
+			// Act
+			table.Columns.AddGeneratedColumn<int, double>(
+				(diameter) => diameter / 2,
+				"Radius",
+				table.Columns["Diameter"]);
+
+			// Assert
+			table.Columns.Count.ShouldBe(6);
+		}
+
+		[Test]
+		public void ColumnGeneratedUsingLocalFunction()
+		{
+			// Arrange
+			var data = DemoDataProvider.ListOfDemoData();
+			var table = Table<Planet>.Create(data);
+
+			double CalculateCircumference(int diameter)
+			{
+				return (diameter * 3.14159 / 2);
+			}
+
+			// Act
+			table.Columns.AddGeneratedColumn<int, double>(
+				CalculateCircumference,
+				"Circumference",
+				table.Columns[2]);
+
+			// Assert
+			table.Columns.Count.ShouldBe(6);
+		}
+
+		[Test]
+		public void ColumnGeneratedUsingComplexTypes()
+		{
+			// Arrange
+			var data = new[]
+				{
+					new { Start = new DateTime(2017, 01, 01), End = new DateTime(2018, 01, 01) },
+					new { Start = new DateTime(1996, 10, 15), End = DateTime.Now.Date },
+					new { Start = new DateTime(1970, 01, 01), End = new DateTime(2038, 01, 19) },
+				};
+
+			var table = Table.Create(data);
+
+			// Act
+			table.Columns.AddGeneratedColumn<DateTime, double>(
+				(start, end) => (end - start).TotalDays,
+				"Total Days",
+				table.Columns[0], table.Columns["End"]);
+
+			// Assert
+			table.Columns.Count.ShouldBe(3);
+		}
+	}
+}

--- a/ConTabs.Tests/GeneratedColumnTests.cs
+++ b/ConTabs.Tests/GeneratedColumnTests.cs
@@ -2,6 +2,8 @@
 using Shouldly;
 using ConTabs.TestData;
 using System;
+using System.Linq;
+using System.Collections.Generic;
 
 namespace ConTabs.Tests
 {
@@ -68,6 +70,64 @@ namespace ConTabs.Tests
 
 			// Assert
 			table.Columns.Count.ShouldBe(3);
+		}
+
+		[Test]
+		public void ColumnGeneratedUsingRangeEntireTable()
+		{
+			// Arrange
+			var data = new[]
+			{
+				new { A = 3, B = 2, C = 6 },
+				new { A = 4, B = 3, C = 7 },
+				new { A = 5, B = 4, C = 8 },
+				new { A = 6, B = 5, C = 9 },
+			};
+
+			var table = Table.Create(data);
+
+			// Act
+			table.Columns.AddGeneratedColumnFromRange<int, int>(
+				(numbers) => numbers.Sum(),
+				"Sum",
+				table.Columns);
+
+			// Assert
+			table.Columns.Count.ShouldBe(4);
+		}
+
+		[Test]
+		public void ColumnGeneratedUsingRangeSpecificColumns()
+		{
+			// Arrange
+			var data = new[]
+			{
+				new { A = 3, B = 2, C = 6, D = 9 },
+				new { A = 4, B = 3, C = 7, D = 10 },
+				new { A = 5, B = 4, C = 8, D = 11 },
+				new { A = 6, B = 5, C = 9, D = 12 },
+			};
+
+			var table = Table.Create(data);
+
+			int ComputeValues(List<int> numbers)
+			{
+				int sum = 0;
+
+				foreach (int num in numbers)
+					sum += num * 3 / 2;
+
+				return sum;
+			}
+
+			// Act
+			table.Columns.AddGeneratedColumnFromRange<int, int>(
+				ComputeValues,
+				"Sum",
+				new List<Column>() { table.Columns[0], table.Columns[1], table.Columns[2]});
+
+			// Assert
+			table.Columns.Count.ShouldBe(5);
 		}
 	}
 }

--- a/ConTabs/Columns.cs
+++ b/ConTabs/Columns.cs
@@ -92,63 +92,63 @@ namespace ConTabs
 		/// <summary>
 		/// Adds a new column to the table of computed values.
 		/// </summary>
-		/// <typeparam name="T">Parameter Type</typeparam>
-		/// <typeparam name="F">Output Type</typeparam>
+		/// <typeparam name="TInput">Parameter Type</typeparam>
+		/// <typeparam name="TOutput">Output Type</typeparam>
 		/// <param name="expression">The expression used to compute values</param>
 		/// <param name="columnName">The name of the new column</param>
-		/// <param name="parameter">The parameter to operate on</param>
-		public void AddGeneratedColumn<T, F>(Func<T, F> expression, string columnName, Column parameter)
+		/// <param name="column">The parameter to operate on</param>
+		public void AddGeneratedColumn<TInput, TOutput>(Func<TInput, TOutput> expression, string columnName, Column column)
 		{
-			var vals = new List<object>();
+            var results = new List<object>();
 
-			for (int i = 0; i < parameter.Values.Count; i++)
-				vals.Add(expression((T)parameter.Values[i]));
+            for (int i = 0; i < column.Values.Count; i++)
+                results.Add(expression((TInput)column.Values[i]));
 
-			this.Add(new Column(typeof(F), columnName) { Values = vals });
+            this.Add(new Column(typeof(TOutput), columnName) { Values = results });
+        }
+
+		/// <summary>
+		/// Adds a new column to the table of computed values.
+		/// </summary>
+		/// <typeparam name="TInput">Parameter Type</typeparam>
+		/// <typeparam name="TOutput">Output Type</typeparam>
+		/// <param name="expression">The expression used to compute values</param>
+		/// <param name="columnName">The name of the new column</param>
+		/// <param name="column1">The first operand within the given expression</param>
+		/// <param name="column2">The second operand within the given expression</param>
+		public void AddGeneratedColumn<TInput, TOutput>(Func<TInput, TInput, TOutput> expression, string columnName, Column column1, Column column2)
+		{
+			var results = new List<object>();
+
+			for (int i = 0; i < column1.Values.Count; i++)
+				results.Add(expression((TInput)column1.Values[i], (TInput)column2.Values[i]));
+
+			this.Add(new Column(typeof(TOutput), columnName) { Values = results });
 		}
 
 		/// <summary>
 		/// Adds a new column to the table of computed values.
 		/// </summary>
-		/// <typeparam name="T">Parameter Type</typeparam>
-		/// <typeparam name="F">Output Type</typeparam>
-		/// <param name="expression">The expression used to compute values</param>
-		/// <param name="columnName">The name of the new column</param>
-		/// <param name="firstOperand">The first operand within the given expression</param>
-		/// <param name="secondOperand">The second operand within the given expression</param>
-		public void AddGeneratedColumn<T, F>(Func<T, T, F> expression, string columnName, Column firstOperand, Column secondOperand)
-		{
-			var vals = new List<object>();
-
-			for (int i = 0; i < firstOperand.Values.Count; i++)
-				vals.Add(expression((T)firstOperand.Values[i], (T)secondOperand.Values[i]));
-
-			this.Add(new Column(typeof(F), columnName) { Values = vals });
-		}
-
-		/// <summary>
-		/// Adds a new column to the table of computed values.
-		/// </summary>
-		/// <typeparam name="T">Parameter Type</typeparam>
-		/// <typeparam name="F">Output Type</typeparam>
+		/// <typeparam name="TInput">Parameter Type</typeparam>
+		/// <typeparam name="TOutput">Output Type</typeparam>
 		/// <param name="expression">The expression used to compute values</param>
 		/// <param name="columnName">The name of the new column</param>
 		/// <param name="columns">A list of the operands to use within the given expression</param>
-		public void AddGeneratedColumnFromRange<T, F>(Func<List<T>, F> expression, string columnName, List<Column> columns)
+		public void AddGeneratedColumnFromRange<TInput, TOutput>(Func<List<TInput>, TOutput> expression, string columnName, List<Column> columns)
 		{
 			var results = new List<object>();
 
 			for (int i = 0; i < columns[0].Values.Count; i++)
 			{
-				var operands = new List<T>();
+				var operands = new List<TInput>();
 
 				foreach (var col in columns)
-					operands.Add((T)col.Values[i]);
+					operands.Add((TInput)col.Values[i]);
 
 				results.Add(expression(operands));
 			}
 
-			this.Add(new Column(typeof(F), columnName) { Values = results });
+			this.Add(new Column(typeof(TOutput), columnName) { Values = results });
 		}
 	}
 }

--- a/ConTabs/Columns.cs
+++ b/ConTabs/Columns.cs
@@ -1,4 +1,5 @@
 ﻿using ConTabs.Exceptions;
+using System;
 using System.Collections.Generic;
 
 namespace ConTabs

--- a/ConTabs/Columns.cs
+++ b/ConTabs/Columns.cs
@@ -87,5 +87,46 @@ namespace ConTabs
             if (backup != null) return backup;
             throw new ColumnNotFoundException(name);
         }
-    }
+
+		/// <summary>
+		/// Adds a new column to the table of computed values.
+		/// </summary>
+		/// <typeparam name="T">Parameter Type</typeparam>
+		/// <typeparam name="F">Output Type</typeparam>
+		/// <param name="expression">The expression used to compute values</param>
+		/// <param name="name">The name of the new column</param>
+		/// <param name="parameter">The parameter to operate on</param>
+		public void AddComputedColumn<T, F>(Func<T, F> expression, string columnName, Column parameter)
+		{
+			var vals = new List<object>();
+
+			for (int i = 0; i < parameter.Values.Count; i++)
+				vals.Add(expression((T)parameter.Values[i]));
+
+			this.Add(new Column(typeof(F), columnName) { Values = vals });
+		}
+
+		/// <summary>
+		/// Adds a new column to the table of computed values.
+		/// </summary>
+		/// <typeparam name="T">Parameter Type</typeparam>
+		/// <typeparam name="F">Output Type</typeparam>
+		/// <param name="expression">The expression used to compute values</param>
+		/// <param name="name">The name of the new column</param>
+		/// <param name="firstOperand">The first operand within the given expression</param>
+		/// <param name="secondOperand">The second operand within the given expression</param>
+		public void AddComputedColumn<T, F>(Func<T, T, F> expression, string columnName, Column firstOperand, Column secondOperand)
+		{
+			//var existingColumnType = this[firstIndex].GetType().GetElementType();
+			// I thought that I could derive the column type from an index within the list,
+			// would love some insight.
+
+			var vals = new List<object>();
+
+			for (int i = 0; i < firstOperand.Values.Count; i++)
+				vals.Add(expression((T)firstOperand.Values[i], (T)secondOperand.Values[i]));
+
+			this.Add(new Column(typeof(F), columnName) { Values = vals });
+		}
+	}
 }

--- a/ConTabs/Columns.cs
+++ b/ConTabs/Columns.cs
@@ -97,7 +97,7 @@ namespace ConTabs
 		/// <param name="expression">The expression used to compute values</param>
 		/// <param name="name">The name of the new column</param>
 		/// <param name="parameter">The parameter to operate on</param>
-		public void AddComputedColumn<T, F>(Func<T, F> expression, string columnName, Column parameter)
+		public void AddGeneratedColumn<T, F>(Func<T, F> expression, string columnName, Column parameter)
 		{
 			var vals = new List<object>();
 
@@ -116,12 +116,8 @@ namespace ConTabs
 		/// <param name="name">The name of the new column</param>
 		/// <param name="firstOperand">The first operand within the given expression</param>
 		/// <param name="secondOperand">The second operand within the given expression</param>
-		public void AddComputedColumn<T, F>(Func<T, T, F> expression, string columnName, Column firstOperand, Column secondOperand)
+		public void AddGeneratedColumn<T, F>(Func<T, T, F> expression, string columnName, Column firstOperand, Column secondOperand)
 		{
-			//var existingColumnType = this[firstIndex].GetType().GetElementType();
-			// I thought that I could derive the column type from an index within the list,
-			// would love some insight.
-
 			var vals = new List<object>();
 
 			for (int i = 0; i < firstOperand.Values.Count; i++)

--- a/ConTabs/Columns.cs
+++ b/ConTabs/Columns.cs
@@ -95,7 +95,7 @@ namespace ConTabs
 		/// <typeparam name="T">Parameter Type</typeparam>
 		/// <typeparam name="F">Output Type</typeparam>
 		/// <param name="expression">The expression used to compute values</param>
-		/// <param name="name">The name of the new column</param>
+		/// <param name="columnName">The name of the new column</param>
 		/// <param name="parameter">The parameter to operate on</param>
 		public void AddGeneratedColumn<T, F>(Func<T, F> expression, string columnName, Column parameter)
 		{
@@ -113,7 +113,7 @@ namespace ConTabs
 		/// <typeparam name="T">Parameter Type</typeparam>
 		/// <typeparam name="F">Output Type</typeparam>
 		/// <param name="expression">The expression used to compute values</param>
-		/// <param name="name">The name of the new column</param>
+		/// <param name="columnName">The name of the new column</param>
 		/// <param name="firstOperand">The first operand within the given expression</param>
 		/// <param name="secondOperand">The second operand within the given expression</param>
 		public void AddGeneratedColumn<T, F>(Func<T, T, F> expression, string columnName, Column firstOperand, Column secondOperand)
@@ -124,6 +124,31 @@ namespace ConTabs
 				vals.Add(expression((T)firstOperand.Values[i], (T)secondOperand.Values[i]));
 
 			this.Add(new Column(typeof(F), columnName) { Values = vals });
+		}
+
+		/// <summary>
+		/// Adds a new column to the table of computed values.
+		/// </summary>
+		/// <typeparam name="T">Parameter Type</typeparam>
+		/// <typeparam name="F">Output Type</typeparam>
+		/// <param name="expression">The expression used to compute values</param>
+		/// <param name="columnName">The name of the new column</param>
+		/// <param name="columns">A list of the operands to use within the given expression</param>
+		public void AddGeneratedColumnFromRange<T, F>(Func<List<T>, F> expression, string columnName, List<Column> columns)
+		{
+			var results = new List<object>();
+
+			for (int i = 0; i < columns[0].Values.Count; i++)
+			{
+				var operands = new List<T>();
+
+				foreach (var col in columns)
+					operands.Add((T)col.Values[i]);
+
+				results.Add(expression(operands));
+			}
+
+			this.Add(new Column(typeof(F), columnName) { Values = results });
 		}
 	}
 }


### PR DESCRIPTION
Added the ability to add generated columns, necessary XML comments, as well as unit tests for such. 

Currently, there are two overloaded methods so that users can create a column operating on a single operand or two operands. Any type is valid and can be created using inline lambda expressions or local functions.  Usage looks like such:
```C#
table.Columns.AddGeneratedColumn<DateTime, double>(    // <input type, output type>
    (start, end) => (end - start).TotalDays,    // Expression
    "Total Days",    // New Column Name
    table.Columns[0], table.Columns["End"]);    // Select Columns
```

Added a new method that supports a List input for several operands. Usage looks like such:
````C#
table.Columns.AddGeneratedColumnFromRange<int, int>(
    (costs) => costs.Sum(),
    "Total",
    table.Columns);
