### PR TITLE
Changing date format tests to use all cultures without hard-coding

### DIFF
--- a/ConTabs.Tests/FormatTests.cs
+++ b/ConTabs.Tests/FormatTests.cs
@@ -9,23 +9,48 @@ namespace ConTabs.Tests
 {
     class FormatTests
     {
-        [Test]
-        public void DateTimeFieldCanBeFormatted()
+        [TestCase("da-DK")]
+        [TestCase("en-GB")]
+        [TestCase("en-US")]
+        [TestCase("sk-SK")]
+        [TestCase("zh-CN")]
+        public void DateTimeFieldCanBeFormattedRegardlessOfCulture(string cultureName)
         {
-            foreach (CultureInfo ci in CultureInfo.GetCultures(CultureTypes.SpecificCultures))
-            {
-                // Arrange
-                Thread.CurrentThread.CurrentCulture = CultureInfo.CreateSpecificCulture(ci.Name);
-                var tableObj = Table<TestDataType>.Create();
+            // Arrange
+            var refDate = new DateTime(2018, 01, 31);
+            var culture = CultureInfo.CreateSpecificCulture(cultureName);
+            Thread.CurrentThread.CurrentCulture = culture;
 
-                // Act
-                tableObj.Columns[3].FormatString = CultureInfo.CurrentCulture.DateTimeFormat.FullDateTimePattern;
-                var val = tableObj.Columns[3].StringValForCol(new DateTime(2018, 01, 31));
-                Console.WriteLine($"Culture {ci.DisplayName} ({ci.Name}): {val}");
+            // Act
+            var tableObj = Table<TestDataType>.Create();
+            tableObj.Columns[3].FormatString = "d-M-yyyy";
+            var val = tableObj.Columns[3].StringValForCol(refDate);
 
-                // Assert
-                val.ShouldBe(new DateTime(2018, 01, 31).ToString(ci.DateTimeFormat.FullDateTimePattern), "Wrong date formatting for culture " + ci.Name);
-            }
+            // Assert
+            val.ShouldBe("31-1-2018");
+        }
+
+        [TestCase("da-DK")]
+        [TestCase("en-GB")]
+        [TestCase("en-US")]
+        [TestCase("sk-SK")]
+        [TestCase("zh-CN")]
+        public void DateTimeFieldCanBeFormattedUsingCulture(string cultureName)
+        {
+            // Arrange
+            var refDate = new DateTime(2018, 01, 31);
+            var formatString = "dddd";
+            var culture = CultureInfo.CreateSpecificCulture(cultureName);
+            Thread.CurrentThread.CurrentCulture = culture;
+            var dateString = refDate.ToString(formatString, culture);
+
+            // Act
+            var tableObj = Table<TestDataType>.Create();
+            tableObj.Columns[3].FormatString = formatString;
+            var val = tableObj.Columns[3].StringValForCol(refDate);
+
+            // Assert
+            val.ShouldBe(dateString);
         }
 
         [TestCase("en-GB", "£1.91")]

--- a/ConTabs.Tests/FormatTests.cs
+++ b/ConTabs.Tests/FormatTests.cs
@@ -9,22 +9,23 @@ namespace ConTabs.Tests
 {
     class FormatTests
     {
-        [TestCase("da"   , "yyyy/MM/dd", "2018-01-31")]
-        [TestCase("en-GB", "dd/MM/yy"  , "31/01/18"  )]
-        [TestCase("en-US", "MM/dd/yy"  , "01/31/18"  )]
-        [TestCase("sk"   , "d/M/yyyy"  , "31.1.2018" )]
-        public void DateTimeFieldCanBeFormatted(string culture, string format, string expected)
+        [Test]
+        public void DateTimeFieldCanBeFormatted()
         {
-            // Arrange
-            Thread.CurrentThread.CurrentCulture = CultureInfo.CreateSpecificCulture(culture);
-            var tableObj = Table<TestDataType>.Create();
+            foreach (CultureInfo ci in CultureInfo.GetCultures(CultureTypes.SpecificCultures))
+            {
+                // Arrange
+                Thread.CurrentThread.CurrentCulture = CultureInfo.CreateSpecificCulture(ci.Name);
+                var tableObj = Table<TestDataType>.Create();
 
-            // Act
-            tableObj.Columns[3].FormatString = format;
-            var val = tableObj.Columns[3].StringValForCol(new DateTime(2018, 01, 31));
-            
-            // Assert
-            val.ShouldBe(expected);
+                // Act
+                tableObj.Columns[3].FormatString = CultureInfo.CurrentCulture.DateTimeFormat.FullDateTimePattern;
+                var val = tableObj.Columns[3].StringValForCol(new DateTime(2018, 01, 31));
+                Console.WriteLine($"Culture {ci.DisplayName} ({ci.Name}): {val}");
+
+                // Assert
+                val.ShouldBe(new DateTime(2018, 01, 31).ToString(ci.DateTimeFormat.FullDateTimePattern), "Wrong date formatting for culture " + ci.Name);
+            }
         }
 
         [TestCase("en-GB", "£1.91")]


### PR DESCRIPTION
Daring change to test to try all the reasonable cultures (skipping custom or invariant) and use the full date format to check whether the formatting works. Daring because I use foreach inside of an AAA pattern and I'll understand if you won't like it.
I also added console output for the test and custom message if the test fails for easier debugs and readability.