### PR TITLE
Basic implementation of a flexible bar chart method

### DIFF
--- a/ConTabs.Tests/BarChartTests.cs
+++ b/ConTabs.Tests/BarChartTests.cs
@@ -1,0 +1,179 @@
+﻿using ConTabs.TestData;
+using NUnit.Framework;
+using Shouldly;
+using System;
+
+namespace ConTabs.Tests
+{
+    [TestFixture]
+    public class BarChartTests
+    {
+        [Test]
+        public void GenerateBarChart_ResultsInNewColumnAdded()
+        {
+            // Arrange
+            var data = DataProvider.ListOfMinimalData();
+            var table = Table.Create(data);
+
+            // Act
+            table.Columns.AddBarChart<int>("Chart", table.Columns["IntB"]);
+
+            // Assert
+            table.Columns.Count.ShouldBe(3);
+        }
+
+        [Test]
+        public void GenerateBarChart_ResultsInStringColumnAdded()
+        {
+            // Arrange
+            var data = DataProvider.ListOfMinimalData();
+            var table = Table.Create(data);
+
+            // Act
+            table.Columns.AddBarChart<int>("Chart", table.Columns["IntB"]);
+
+            // Assert
+            table.Columns[2].SourceType.ShouldBe(typeof(string));
+        }
+
+        [Test]
+        public void GenerateBarChart_WithDefaultParams_BarsAreExpectedSize()
+        {
+            // Arrange
+            var data = DataProvider.ListOfMinimalData(3); // IntB = 3, 9, 27
+            var table = Table.Create(data);
+
+            // Act
+            table.Columns.AddBarChart<int>("Chart", table.Columns["IntB"]); // Max = 27, default width = 25, unit scale = 25/27 = 0.92592...
+
+            // Assert
+            table.Columns[2].Values[0].ShouldBe("###");                         // 0.92592 *  3 =  2.77 = 3
+            table.Columns[2].Values[1].ShouldBe("########");                    // 0.92592 *  9 =  8.33 = 8
+            table.Columns[2].Values[2].ShouldBe("#########################");   // 0.92592 * 27 = 25.00 = 25
+        }
+
+        [Test]
+        public void GenerateBarChart_MaxWidthCanBeSpecified()
+        {
+            // Arrange
+            var data = DataProvider.ListOfMinimalData(1); // single row, IntB = 3
+            var table = Table.Create(data);
+
+            // Act
+            table.Columns.AddBarChart<int>("Chart", table.Columns["IntB"], maxLength: 3);
+
+            // Assert
+            table.Columns[2].Values[0].ShouldBe("###");
+        }
+
+        [Test]
+        public void GenerateBarChart_ForSingleValues_ResultsInFullWidthBar()
+        {
+            // Arrange
+            var data = DataProvider.ListOfMinimalData(1); // single row, IntB = 3
+            var table = Table.Create(data);
+
+            // Act
+            table.Columns.AddBarChart<int>("Chart", table.Columns["IntB"], maxLength: 10);
+
+            // Assert
+            table.Columns[2].Values[0].ShouldBe("##########"); // count = 10 = maxLength
+        }
+
+        [Test]
+        public void GenerateBarChart_UnitCharCanBeChanged()
+        {
+            // Arrange
+            var data = DataProvider.ListOfMinimalData(1); // single row, IntB = 3
+            var table = Table.Create(data);
+
+            // Act
+            table.Columns.AddBarChart<int>("Chart", table.Columns["IntB"], maxLength:3, unitChar: '>');
+
+            // Assert
+            table.Columns[2].Values[0].ShouldBe(">>>");
+        }
+
+        [Test]
+        public void GenerateBarChart_ScaleCanBeSpecified()
+        {
+            // Arrange
+            var data = DataProvider.ListOfMinimalData(1); // single row, IntB = 3
+            var table = Table.Create(data);
+
+            // Act
+            table.Columns.AddBarChart<int>("Chart", table.Columns["IntB"], unitSize: 3);
+
+            // Assert
+            table.Columns[2].Values[0].ShouldBe("#"); // one unit of size 3, for a value of 3
+        }
+
+        [Test]
+        public void GenerateBarChart_WhenBothScaleAndMaxWidthAreSpecified_ScaleTakesPrecedence()
+        {
+            // Arrange
+            var data = DataProvider.ListOfMinimalData(1); // single row, IntB = 3
+            var table = Table.Create(data);
+
+            // Act
+            table.Columns.AddBarChart<int>("Chart", table.Columns["IntB"], unitSize: 3, maxLength: 9);
+
+            // Assert
+            table.Columns[2].Values[0].ShouldBe("#"); // one unit of size 3, for a value of 3, rather than 100% of maxLength
+        }
+
+        [Test]
+        public void GenerateBarChart_WhenBothScaleAndMaxWidthAreSpecified_NeverExceedsMax()
+        {
+            // Arrange
+            var data = DataProvider.ListOfMinimalData(3); // single row, IntB = 3
+            var table = Table.Create(data);
+
+            // Act
+            table.Columns.AddBarChart<int>("Chart", table.Columns["IntB"], unitSize: 3, maxLength: 5);
+
+            // Assert
+            table.Columns[2].Values[0].ShouldBe("#");
+            table.Columns[2].Values[1].ShouldBe("###");
+            table.Columns[2].Values[2].ShouldBe("#####"); // capped at 5 instead of value 27 / scale 3 = 9 units
+        }
+
+        [Test]
+        public void GenerateBarChart_NegativeValuesGetHandledGracefully()
+        {
+            // Arrange
+            var data = DataProvider.ListOfMinimalData(1); // single row, IntB = 3
+            data[0].IntB = -1;
+            var table = Table.Create(data);
+
+            // Act
+            table.Columns.AddBarChart<int>("Chart", table.Columns["IntB"]);
+
+            // Assert
+            table.Columns[2].Values[0].ShouldBe("");
+        }
+
+        [Test]
+        public void GenerateBarChart_ConformanceTest()
+        {
+            // Arrange
+            var data = DataProvider.ListOfMinimalData(3); // IntB = 3, 9, 27
+            var table = Table.Create(data);
+
+            // Act
+            table.Columns.AddBarChart<int>("Chart", table.Columns["IntB"], maxLength: 10, unitChar: '=');
+
+            // Assert
+            string expected = "";
+            expected += "+------+------+------------+" + Environment.NewLine;
+            expected += "| IntA | IntB | Chart      |" + Environment.NewLine;
+            expected += "+------+------+------------+" + Environment.NewLine;
+            expected += "| 1    | 3    | =          |" + Environment.NewLine;
+            expected += "| 2    | 9    | ===        |" + Environment.NewLine;
+            expected += "| 3    | 27   | ========== |" + Environment.NewLine;
+            expected += "+------+------+------------+";
+
+            table.ToString().ShouldBe(expected);
+        }
+    }
+}

--- a/ConTabs.Tests/ConTabs.Tests.csproj
+++ b/ConTabs.Tests/ConTabs.Tests.csproj
@@ -61,6 +61,7 @@
     <Reference Include="System.Core" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="BarChartTests.cs" />
     <Compile Include="ColumnAttributeTests.cs" />
     <Compile Include="ConformanceTests.cs" />
     <Compile Include="FormatTests.cs" />

--- a/ConTabs/Columns.cs
+++ b/ConTabs/Columns.cs
@@ -202,7 +202,8 @@ namespace ConTabs
         /// <param name="unitChar">The character used to build the bar (Optional; default = '#')</param>
         /// <param name="unitSize">The value of each unit (Optional; defaults to being dynamic based on the max value)</param>
         /// <param name="maxLength">The maximum width of a bar (Optional; defaults to 25)</param>
-        public void AddBarChart<TInput> (string columnName, Column sourceColumn, char unitChar = '#', double? unitSize = null, int maxLength = 25) where TInput : unmanaged, IComparable<TInput>
+        public void AddBarChart<TInput> (string columnName, Column sourceColumn, char unitChar = '#', double? unitSize = null, int maxLength = 25)
+            where TInput : unmanaged, IComparable, IEquatable<TInput> // from https://stackoverflow.com/a/60022011/50151 (better support coming in future versions of .NET)
         {
             if (unitSize is null)
             {

--- a/ConTabs/Columns.cs
+++ b/ConTabs/Columns.cs
@@ -192,5 +192,36 @@ namespace ConTabs
 
             Add(new Column(typeof(TOutput), columnName) { Values = results });
         }
+
+        public void AddBarChart<TInput> (string columnName, Column sourceColumn, char unitChar = '#', double? unitSize = null, int maxLength = 25) where TInput : unmanaged, IComparable<TInput>
+        {
+            if (unitSize is null)
+            {
+                var max = sourceColumn.Values.Select(v => Convert.ToDouble(v)).Max();
+                unitSize = max / maxLength;
+            }
+
+            AddGeneratedColumn<TInput, string>(
+                d =>
+                {
+                    var d_casted = Convert.ToDouble(d);
+                    var size = (int)Math.Round(d_casted / unitSize.Value);
+                    
+                    if (size < 0 || d_casted < 0)
+                    {
+                        size = 0;
+                    }
+
+                    if (size > maxLength)
+                    {
+                        size = maxLength;
+                    }
+
+                    return new string(unitChar, size);
+                },
+                columnName,
+                sourceColumn
+            );
+        }
     }
 }

--- a/ConTabs/Columns.cs
+++ b/ConTabs/Columns.cs
@@ -193,6 +193,15 @@ namespace ConTabs
             Add(new Column(typeof(TOutput), columnName) { Values = results });
         }
 
+        /// <summary>
+        /// Adds a special bar chart column based on another numeric column.
+        /// </summary>
+        /// <typeparam name="TInput">Type of source column (should be numeric)</typeparam>
+        /// <param name="columnName">The name of the new column</param>
+        /// <param name="sourceColumn">The column from which to derive the bar chart</param>
+        /// <param name="unitChar">The character used to build the bar (Optional; default = '#')</param>
+        /// <param name="unitSize">The value of each unit (Optional; defaults to being dynamic based on the max value)</param>
+        /// <param name="maxLength">The maximum width of a bar (Optional; defaults to 25)</param>
         public void AddBarChart<TInput> (string columnName, Column sourceColumn, char unitChar = '#', double? unitSize = null, int maxLength = 25) where TInput : unmanaged, IComparable<TInput>
         {
             if (unitSize is null)


### PR DESCRIPTION
Added a method to the Columns class to handle the generation of "bar chart" columns from numeric data types.

Method has options to specify:
1. The character used to build the bar (default = '#')
2. The max width of the bars (default = 25)
3. The "scale" of each unit (defaults to dynamic based on max value and max width)

Tests should cover most cases.